### PR TITLE
Add top-level CLI for running lab demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ pip install -r requirements.txt
 
 ## How to run
 
+## One entry point (interactive CLI)
+```bash
+python lab2_cli.py
+```
+
+## Non-interactive
+
+```bash
+python lab2_cli.py --run aes
+python lab2_cli.py --run rsa
+python lab2_cli.py --run dh
+python lab2_cli.py --run ecdh
+python lab2_cli.py --run bleichenbacher
+python lab2_cli.py --run all
+```
+
 ```bash
 python aes_modes/ecb_cbc_gcm.py
 python rsa/rsa_from_scratch.py


### PR DESCRIPTION
## Summary
- add a unified `lab2_cli.py` entry point with an interactive menu and `--run` flag for demos
- document the new CLI workflow alongside existing module-level scripts in the README

## Testing
- python lab2_cli.py --run aes *(fails: ModuleNotFoundError: No module named 'Crypto'; dependency not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e04a683a108320b583ca87ac5be35f