### PR TITLE
Add AES GCM keystream reuse demo

### DIFF
--- a/lab2_cli.py
+++ b/lab2_cli.py
@@ -26,6 +26,7 @@ from aes_modes.ecb_cbc_gcm import (
     demo_ecb_pattern_leakage,
     demo_cbc_iv_reuse,
     demo_gcm_nonce_reuse,
+    demo_gcm_keystream_reuse_xor_leak,
 )
 
 # RSA: build a small roundtrip using the provided primitives
@@ -82,6 +83,8 @@ def run_aes():
     demo_ecb_pattern_leakage()
     demo_cbc_iv_reuse()
     demo_gcm_nonce_reuse()
+    print("[GCM] Demonstrating keystream reuse XOR leakage...")
+    demo_gcm_keystream_reuse_xor_leak()
     print("AES demos done.")
     line()
 


### PR DESCRIPTION
## Summary
- add a demo showing ciphertext XOR leakage under AES-GCM keystream reuse
- wire the new demo into the AES CLI command flow

## Testing
- python -m compileall aes_modes/ecb_cbc_gcm.py lab2_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e04deed650832087344b0aeab8540f