### PR TITLE
Bootstrap lab2 CLI environment automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ This repository contains reference implementations for:
 
 ## Quickstart
 
+Just run the CLI entry point – it now bootstraps a local virtual environment
+and installs `requirements.txt` automatically on first use:
+
+```bash
+python lab2_cli.py
+```
+
+Prefer to manage the environment manually? You still can:
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate

--- a/lab2_cli.py
+++ b/lab2_cli.py
@@ -16,10 +16,140 @@ Usage:
 """
 
 from __future__ import annotations
-import argparse
-import textwrap
 
-# --- Imports from your repo modules (ensure you run from repo root) ---
+import argparse
+import hashlib
+import importlib
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def _venv_python_path(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _requirements_marker_path(base_dir: Path, python_executable: Path) -> Path:
+    # Use a short hash of the interpreter path to avoid collisions when users
+    # run the CLI from multiple environments (e.g., system Python vs venv).
+    digest = hashlib.sha256(str(python_executable).encode()).hexdigest()[:16]
+    return base_dir / f".requirements_{digest}"
+
+
+_REQUIREMENT_IMPORTS = {
+    "pycryptodome": ["Crypto"],
+    "tinyec": ["tinyec"],
+    "matplotlib": ["matplotlib"],
+}
+
+
+def _requirements_already_available(requirements_path: Path) -> bool:
+    """Return True if every requirement can already be imported."""
+
+    for raw_line in requirements_path.read_text().splitlines():
+        requirement = raw_line.strip()
+        if not requirement or requirement.startswith("#"):
+            continue
+
+        modules = _REQUIREMENT_IMPORTS.get(requirement)
+        if not modules:
+            # Unknown requirement — we can't reliably check, so request install.
+            return False
+
+        for module_name in modules:
+            try:
+                importlib.import_module(module_name)
+            except Exception:
+                return False
+
+    return True
+
+
+def _ensure_requirements_installed(
+    python_executable: Path,
+    requirements_path: Path,
+    marker_path: Path,
+) -> None:
+    """Install requirements if the hash has changed since the last run."""
+
+    if not requirements_path.exists():
+        return
+
+    req_hash = hashlib.sha256(requirements_path.read_bytes()).hexdigest()
+    if marker_path.exists() and marker_path.read_text().strip() == req_hash:
+        return
+
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if _requirements_already_available(requirements_path):
+        marker_path.write_text(req_hash)
+        return
+
+    subprocess.check_call([
+        str(python_executable),
+        "-m",
+        "pip",
+        "install",
+        "-r",
+        str(requirements_path),
+    ])
+
+    marker_path.write_text(req_hash)
+
+
+def _running_in_any_virtualenv() -> bool:
+    base_prefix = getattr(sys, "base_prefix", sys.prefix)
+    return sys.prefix != base_prefix
+
+
+def _running_in_repo_venv(venv_dir: Path, python_in_venv: Path) -> bool:
+    env_path = os.environ.get("VIRTUAL_ENV")
+    if env_path and Path(env_path).resolve() == venv_dir.resolve():
+        return True
+    try:
+        return Path(sys.executable).resolve() == python_in_venv.resolve()
+    except FileNotFoundError:
+        return False
+
+
+def ensure_environment() -> None:
+    """Ensure a virtual environment exists with all requirements installed."""
+
+    repo_root = Path(__file__).resolve().parent
+    venv_dir = repo_root / ".venv"
+    python_in_venv = _venv_python_path(venv_dir)
+    requirements_path = repo_root / "requirements.txt"
+
+    if _running_in_repo_venv(venv_dir, python_in_venv):
+        marker = venv_dir / ".requirements_hash"
+        _ensure_requirements_installed(Path(sys.executable), requirements_path, marker)
+        return
+
+    if _running_in_any_virtualenv():
+        marker = _requirements_marker_path(repo_root, Path(sys.executable))
+        _ensure_requirements_installed(Path(sys.executable), requirements_path, marker)
+        return
+
+    if not venv_dir.exists():
+        subprocess.check_call([sys.executable, "-m", "venv", str(venv_dir)])
+
+    marker = venv_dir / ".requirements_hash"
+    _ensure_requirements_installed(python_in_venv, requirements_path, marker)
+
+    os.execv(
+        str(python_in_venv),
+        [str(python_in_venv), str(repo_root / "lab2_cli.py"), *sys.argv[1:]],
+    )
+
+
+ensure_environment()
+
+
+# --- Imports from your repo modules (after the environment is ready) ---
 # AES demos (functions already exist in aes_modes/ecb_cbc_gcm.py)
 from aes_modes.ecb_cbc_gcm import (
     roundtrip_checks as aes_roundtrip,


### PR DESCRIPTION
## Summary
- add environment bootstrap logic to `lab2_cli.py`, creating `.venv` and installing requirements as needed
- detect already-installed dependencies to avoid unnecessary pip calls and support existing virtualenvs
- update the README quickstart instructions to note the automated setup

## Testing
- python lab2_cli.py --run rsa

------
https://chatgpt.com/codex/tasks/task_e_68e165249c34832096b997a081e0adb5