### PR TITLE
Add file encryption helpers for RSA, DH, and ECDH

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ python ecdh/ecdh_tinyec.py
 python attacks/bleichenbacher_oracle.py  # optional scaffold
 ```
 
+### File-based encryption helpers
+
+The interactive CLI now provides helper utilities to encrypt/decrypt short
+messages to JSON bundles using several algorithms:
+
+- **AES (ECB/CBC/GCM)** — original helpers retained under `EncryptedFiles/`.
+- **RSA** — generates textbook RSA key pairs (no padding) and stores ciphertext
+  bundles in `EncryptedFiles/RSA/`.
+- **Diffie–Hellman (finite field)** — derives an AES-GCM key from the shared
+  secret and stores metadata in `EncryptedFiles/DH/`.
+- **Elliptic-Curve Diffie–Hellman** — derives an AES-GCM key on a TinyEC curve
+  and stores metadata in `EncryptedFiles/ECDH/`.
+
+Each helper offers the option to omit secret material from the JSON bundle, in
+which case the CLI prints the necessary key so it can be recorded securely.
+
 See `aes_modes/README.md` for AES-specific notes.
 
 ## Report

--- a/dh/dh_file_io.py
+++ b/dh/dh_file_io.py
@@ -1,0 +1,261 @@
+"""Helper utilities for Diffie–Hellman-based file encryption using AES-GCM."""
+from __future__ import annotations
+
+import base64
+import json
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from Crypto.Cipher import AES
+from Crypto.Random import get_random_bytes
+
+from dh.dh_small_prime import p as GROUP_P, g as GROUP_G
+
+
+@dataclass(frozen=True)
+class DhPrivate:
+    value: int
+
+
+class MissingSecretError(ValueError):
+    """Raised when the DH private value is required but missing."""
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def _b64decode(value: str, *, field: str) -> bytes:
+    try:
+        return base64.b64decode(value, validate=True)
+    except Exception as exc:  # binascii.Error, ValueError
+        raise ValueError(f"Invalid base64 value for '{field}'") from exc
+
+
+def _derive_key(shared_secret: int) -> bytes:
+    secret_bytes = shared_secret.to_bytes((GROUP_P.bit_length() + 7) // 8, "big")
+    return hashlib.sha256(secret_bytes).digest()
+
+
+def encrypt_to_file(
+    plaintext: bytes | bytearray | memoryview,
+    out_path: str | Path,
+    *,
+    store_private: bool = False,
+) -> tuple[DhPrivate, int, int]:
+    """Encrypt *plaintext* using DH-derived AES-GCM key and persist to JSON."""
+
+    if not isinstance(plaintext, (bytes, bytearray, memoryview)):
+        raise TypeError("plaintext must be bytes-like")
+    message = bytes(plaintext)
+
+    from secrets import randbelow
+
+    a = randbelow(GROUP_P - 2) + 1
+    b = randbelow(GROUP_P - 2) + 1
+    A = pow(GROUP_G, a, GROUP_P)
+    B = pow(GROUP_G, b, GROUP_P)
+    shared = pow(B, a, GROUP_P)
+
+    key = _derive_key(shared)
+    nonce = get_random_bytes(12)
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    ciphertext, tag = cipher.encrypt_and_digest(message)
+
+    bundle: dict[str, Any] = {
+        "alg": "DH",
+        "v": 1,
+        "group": {
+            "p": str(GROUP_P),
+            "g": GROUP_G,
+        },
+        "public": {
+            "A": str(A),
+            "B": str(B),
+        },
+        "ciphertext_b64": _b64encode(ciphertext),
+        "nonce_b64": _b64encode(nonce),
+        "tag_b64": _b64encode(tag),
+        "plaintext_len": len(message),
+    }
+
+    if store_private:
+        bundle["private"] = {"a": format(a, "x")}
+
+    stored = DhPrivate(value=a)
+
+    output_path = Path(out_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(bundle, indent=2) + "\n")
+
+    return stored, A, B
+
+
+def decrypt_from_file(
+    in_path: str | Path,
+    *,
+    private_value: DhPrivate | None = None,
+) -> bytes:
+    """Decrypt a DH AES-GCM JSON bundle and return the plaintext."""
+
+    path = Path(in_path)
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"File not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError("Input file is not valid JSON") from exc
+
+    if data.get("alg") != "DH":
+        raise ValueError("Input file does not contain Diffie–Hellman data")
+
+    public = data.get("public") or {}
+    try:
+        A = int(public["A"])
+        B = int(public["B"])
+        plaintext_len = int(data["plaintext_len"])
+    except KeyError as exc:
+        raise ValueError(f"Missing required DH field: {exc.args[0]}") from exc
+    except ValueError as exc:
+        raise ValueError("DH metadata contains invalid integers") from exc
+
+    priv_in_file = data.get("private", {}).get("a")
+    if private_value is None:
+        if priv_in_file is None:
+            raise MissingSecretError(
+                "DH private value required but not provided and not stored in file."
+            )
+        private_value = DhPrivate(value=int(priv_in_file, 16))
+
+    shared = pow(B, private_value.value, GROUP_P)
+
+    key = _derive_key(shared)
+
+    ciphertext_b64 = data.get("ciphertext_b64")
+    nonce_b64 = data.get("nonce_b64")
+    tag_b64 = data.get("tag_b64")
+    if not ciphertext_b64 or not nonce_b64 or not tag_b64:
+        raise ValueError("Missing ciphertext, nonce, or tag for DH bundle")
+
+    ciphertext = _b64decode(ciphertext_b64, field="ciphertext_b64")
+    nonce = _b64decode(nonce_b64, field="nonce_b64")
+    tag = _b64decode(tag_b64, field="tag_b64")
+
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    try:
+        plaintext = cipher.decrypt_and_verify(ciphertext, tag)
+    except ValueError as exc:
+        raise ValueError("GCM authentication failed. Secret or ciphertext incorrect.") from exc
+
+    if plaintext_len != len(plaintext):
+        plaintext = plaintext[:plaintext_len]
+    return plaintext
+
+
+def run_encrypt_console() -> None:
+    """Interactive prompt for DH encryption to a JSON file."""
+
+    print("-- DH Encrypt to File --")
+    plaintext = input("Enter plaintext: ").encode("utf-8")
+
+    store_private_answer = input("Store private value in file? (y/N): ").strip().lower()
+    store_private = store_private_answer in {"y", "yes"}
+
+    output_dir = Path("EncryptedFiles") / "DH"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    name_hint = input("Name for output file (optional): ").strip()
+    if not name_hint:
+        name_hint = "dh"
+    sanitized = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in name_hint)
+    if not sanitized:
+        sanitized = "dh"
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_file = output_dir / f"{sanitized}_{timestamp}.json"
+
+    try:
+        private_value, A, B = encrypt_to_file(
+            plaintext,
+            out_file,
+            store_private=store_private,
+        )
+    except Exception as exc:
+        print(f"Encryption failed: {exc}")
+        return
+
+    print("DH encrypted data saved to:")
+    print(f"  {out_file.resolve()}")
+    print("Public values (hex):")
+    print(f"  A = {A:#x}")
+    print(f"  B = {B:#x}")
+
+    if not store_private:
+        print("Private value (hex) — keep this safe:")
+        print(f"  a = {private_value.value:#x}")
+
+
+def run_decrypt_console() -> None:
+    """Interactive prompt for DH decryption from a JSON file."""
+
+    print("-- DH Decrypt from File --")
+    encrypted_dir = Path("EncryptedFiles") / "DH"
+    if not encrypted_dir.exists():
+        print("No DH encrypted files found.")
+        return
+
+    files = sorted(file for file in encrypted_dir.iterdir() if file.suffix == ".json")
+    if not files:
+        print("No DH JSON files available.")
+        return
+
+    print("Available DH files:")
+    for idx, file in enumerate(files, start=1):
+        print(f"  {idx}) {file.name}")
+
+    while True:
+        selection = input("Select a file number to decrypt (or 'q' to cancel): ").strip()
+        if selection.lower() in {"q", "quit", "exit", "0"}:
+            print("Decryption cancelled.")
+            return
+        try:
+            choice = int(selection)
+        except ValueError:
+            print("Invalid selection. Enter a number or 'q'.")
+            continue
+        if not 1 <= choice <= len(files):
+            print("Selection out of range. Try again.")
+            continue
+        in_file = files[choice - 1]
+        break
+
+    try:
+        plaintext = decrypt_from_file(in_file)
+    except MissingSecretError:
+        key_input = input("Private value not in file. Enter a (decimal or 0x-hex): ").strip()
+        if not key_input:
+            print("No private value provided. Aborting.")
+            return
+        try:
+            value = int(key_input, 0)
+        except ValueError:
+            print("Invalid private value.")
+            return
+        try:
+            plaintext = decrypt_from_file(in_file, private_value=DhPrivate(value=value))
+        except Exception as exc:
+            print(f"Decryption failed: {exc}")
+            return
+    except Exception as exc:
+        print(f"Decryption failed: {exc}")
+        return
+
+    try:
+        decoded = plaintext.decode("utf-8")
+    except UnicodeDecodeError:
+        decoded = plaintext.decode("utf-8", errors="replace")
+    print("Recovered plaintext:")
+    print(decoded)

--- a/ecdh/ecdh_file_io.py
+++ b/ecdh/ecdh_file_io.py
@@ -1,0 +1,288 @@
+"""Helper utilities for ECDH-based file encryption using AES-GCM."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from Crypto.Cipher import AES
+from Crypto.Random import get_random_bytes
+from tinyec import registry
+
+
+@dataclass(frozen=True)
+class EcdhPrivate:
+    value: int
+    curve_name: str
+
+
+class MissingScalarError(ValueError):
+    """Raised when the ECDH private scalar is required but missing."""
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def _b64decode(value: str, *, field: str) -> bytes:
+    try:
+        return base64.b64decode(value, validate=True)
+    except Exception as exc:  # binascii.Error, ValueError
+        raise ValueError(f"Invalid base64 value for '{field}'") from exc
+
+
+def _derive_key(curve, shared_point) -> bytes:
+    coord_size = (curve.field.p.bit_length() + 7) // 8
+    x_bytes = int(shared_point.x).to_bytes(coord_size, "big")
+    return hashlib.sha256(x_bytes).digest()
+
+
+def encrypt_to_file(
+    plaintext: bytes | bytearray | memoryview,
+    out_path: str | Path,
+    *,
+    curve_name: str = "secp256r1",
+    store_private: bool = False,
+) -> tuple[EcdhPrivate, tuple[int, int], tuple[int, int]]:
+    """Encrypt *plaintext* using an ECDH-derived AES key and persist to JSON."""
+
+    if not isinstance(plaintext, (bytes, bytearray, memoryview)):
+        raise TypeError("plaintext must be bytes-like")
+    message = bytes(plaintext)
+
+    curve = registry.get_curve(curve_name)
+    n = curve.field.n
+
+    from secrets import randbelow
+
+    dA = randbelow(n - 1) + 1
+    dB = randbelow(n - 1) + 1
+    QA = dA * curve.g
+    QB = dB * curve.g
+    shared = dA * QB
+
+    key = _derive_key(curve, shared)
+    nonce = get_random_bytes(12)
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    ciphertext, tag = cipher.encrypt_and_digest(message)
+
+    bundle: dict[str, Any] = {
+        "alg": "ECDH",
+        "v": 1,
+        "curve": curve.name,
+        "public": {
+            "QA": {"x": format(QA.x, "x"), "y": format(QA.y, "x")},
+            "QB": {"x": format(QB.x, "x"), "y": format(QB.y, "x")},
+        },
+        "ciphertext_b64": _b64encode(ciphertext),
+        "nonce_b64": _b64encode(nonce),
+        "tag_b64": _b64encode(tag),
+        "plaintext_len": len(message),
+    }
+
+    if store_private:
+        bundle["private"] = {"dA": format(dA, "x")}
+
+    output_path = Path(out_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(bundle, indent=2) + "\n")
+
+    stored = EcdhPrivate(value=dA, curve_name=curve.name)
+    return stored, (QA.x, QA.y), (QB.x, QB.y)
+
+
+def decrypt_from_file(
+    in_path: str | Path,
+    *,
+    private_scalar: EcdhPrivate | None = None,
+) -> bytes:
+    """Decrypt an ECDH AES-GCM JSON bundle and return the plaintext."""
+
+    path = Path(in_path)
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"File not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError("Input file is not valid JSON") from exc
+
+    if data.get("alg") != "ECDH":
+        raise ValueError("Input file does not contain ECDH data")
+
+    curve_name = data.get("curve")
+    if not curve_name:
+        raise ValueError("Missing curve information in ECDH file")
+    curve = registry.get_curve(curve_name)
+
+    try:
+        QA_data = data["public"]["QA"]
+        QB_data = data["public"]["QB"]
+        QA = (int(QA_data["x"], 16), int(QA_data["y"], 16))
+        QB = (int(QB_data["x"], 16), int(QB_data["y"], 16))
+        plaintext_len = int(data["plaintext_len"])
+    except KeyError as exc:
+        raise ValueError(f"Missing required ECDH field: {exc.args[0]}") from exc
+    except ValueError as exc:
+        raise ValueError("ECDH metadata contains invalid integers") from exc
+
+    priv_in_file = data.get("private", {}).get("dA")
+    if private_scalar is None:
+        if priv_in_file is None:
+            raise MissingScalarError(
+                "ECDH private scalar required but not provided and not stored in file."
+            )
+        private_scalar = EcdhPrivate(value=int(priv_in_file, 16), curve_name=curve_name)
+
+    if private_scalar.curve_name != curve_name:
+        raise ValueError("Provided private scalar does not match curve in file")
+
+    # reconstruct points
+    QA_point = curve.point(QA[0], QA[1])
+    QB_point = curve.point(QB[0], QB[1])
+
+    shared = private_scalar.value * QB_point
+    key = _derive_key(curve, shared)
+
+    ciphertext_b64 = data.get("ciphertext_b64")
+    nonce_b64 = data.get("nonce_b64")
+    tag_b64 = data.get("tag_b64")
+    if not ciphertext_b64 or not nonce_b64 or not tag_b64:
+        raise ValueError("Missing ciphertext, nonce, or tag for ECDH bundle")
+
+    ciphertext = _b64decode(ciphertext_b64, field="ciphertext_b64")
+    nonce = _b64decode(nonce_b64, field="nonce_b64")
+    tag = _b64decode(tag_b64, field="tag_b64")
+
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    try:
+        plaintext = cipher.decrypt_and_verify(ciphertext, tag)
+    except ValueError as exc:
+        raise ValueError("GCM authentication failed. Secret or ciphertext incorrect.") from exc
+
+    if plaintext_len != len(plaintext):
+        plaintext = plaintext[:plaintext_len]
+    return plaintext
+
+
+def run_encrypt_console() -> None:
+    """Interactive prompt for ECDH encryption to a JSON file."""
+
+    print("-- ECDH Encrypt to File --")
+    plaintext = input("Enter plaintext: ").encode("utf-8")
+    curve_name = input("Curve name (default secp256r1): ").strip() or "secp256r1"
+
+    store_private_answer = input("Store private scalar in file? (y/N): ").strip().lower()
+    store_private = store_private_answer in {"y", "yes"}
+
+    output_dir = Path("EncryptedFiles") / "ECDH"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    name_hint = input("Name for output file (optional): ").strip()
+    if not name_hint:
+        name_hint = "ecdh"
+    sanitized = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in name_hint)
+    if not sanitized:
+        sanitized = "ecdh"
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_file = output_dir / f"{sanitized}_{timestamp}.json"
+
+    try:
+        private_scalar, QA, QB = encrypt_to_file(
+            plaintext,
+            out_file,
+            curve_name=curve_name,
+            store_private=store_private,
+        )
+    except Exception as exc:
+        print(f"Encryption failed: {exc}")
+        return
+
+    print("ECDH encrypted data saved to:")
+    print(f"  {out_file.resolve()}")
+    print(f"Curve: {curve_name}")
+    print("Public points (hex):")
+    print(f"  QA.x = {QA[0]:#x}")
+    print(f"  QA.y = {QA[1]:#x}")
+    print(f"  QB.x = {QB[0]:#x}")
+    print(f"  QB.y = {QB[1]:#x}")
+
+    if not store_private:
+        print("Private scalar (hex) — keep this safe:")
+        print(f"  dA = {private_scalar.value:#x}")
+
+
+def run_decrypt_console() -> None:
+    """Interactive prompt for ECDH decryption from a JSON file."""
+
+    print("-- ECDH Decrypt from File --")
+    encrypted_dir = Path("EncryptedFiles") / "ECDH"
+    if not encrypted_dir.exists():
+        print("No ECDH encrypted files found.")
+        return
+
+    files = sorted(file for file in encrypted_dir.iterdir() if file.suffix == ".json")
+    if not files:
+        print("No ECDH JSON files available.")
+        return
+
+    print("Available ECDH files:")
+    for idx, file in enumerate(files, start=1):
+        print(f"  {idx}) {file.name}")
+
+    while True:
+        selection = input("Select a file number to decrypt (or 'q' to cancel): ").strip()
+        if selection.lower() in {"q", "quit", "exit", "0"}:
+            print("Decryption cancelled.")
+            return
+        try:
+            choice = int(selection)
+        except ValueError:
+            print("Invalid selection. Enter a number or 'q'.")
+            continue
+        if not 1 <= choice <= len(files):
+            print("Selection out of range. Try again.")
+            continue
+        in_file = files[choice - 1]
+        break
+
+    try:
+        plaintext = decrypt_from_file(in_file)
+    except MissingScalarError:
+        key_input = input("Private scalar not in file. Enter dA (decimal or 0x-hex): ").strip()
+        if not key_input:
+            print("No private scalar provided. Aborting.")
+            return
+        try:
+            value = int(key_input, 0)
+        except ValueError:
+            print("Invalid private scalar.")
+            return
+        try:
+            with open(in_file, "r", encoding="utf-8") as f:
+                curve_name = json.load(f)["curve"]
+        except Exception as exc:
+            print(f"Unable to read curve from file: {exc}")
+            return
+        try:
+            plaintext = decrypt_from_file(
+                in_file,
+                private_scalar=EcdhPrivate(value=value, curve_name=curve_name),
+            )
+        except Exception as exc:
+            print(f"Decryption failed: {exc}")
+            return
+    except Exception as exc:
+        print(f"Decryption failed: {exc}")
+        return
+
+    try:
+        decoded = plaintext.decode("utf-8")
+    except UnicodeDecodeError:
+        decoded = plaintext.decode("utf-8", errors="replace")
+    print("Recovered plaintext:")
+    print(decoded)

--- a/lab2_cli.py
+++ b/lab2_cli.py
@@ -36,14 +36,28 @@ from rsa.rsa_from_scratch import (
     i2osp, os2ip,
     encrypt_int, decrypt_int,
 )
+from rsa.rsa_file_io import (
+    run_encrypt_console as run_rsa_encrypt_console,
+    run_decrypt_console as run_rsa_decrypt_console,
+)
 
 # DH / ECDH have demo() functions
 from dh.dh_small_prime import demo as dh_demo
+from dh.dh_file_io import (
+    run_encrypt_console as run_dh_encrypt_console,
+    run_decrypt_console as run_dh_decrypt_console,
+)
 
 try:
     from ecdh.ecdh_tinyec import demo as ecdh_demo
+    from ecdh.ecdh_file_io import (
+        run_encrypt_console as run_ecdh_encrypt_console,
+        run_decrypt_console as run_ecdh_decrypt_console,
+    )
 except Exception as e:
     ecdh_demo = None
+    run_ecdh_encrypt_console = None
+    run_ecdh_decrypt_console = None
     _ecdh_import_error = e
 
 # Bleichenbacher oracle scaffold (optional)
@@ -115,7 +129,7 @@ def run_aes(run_default: bool = False):
         else:
             print("Invalid option. Choose 0-3.")
 
-def run_rsa():
+def _run_rsa_demo():
     line()
     print("== RSA Round-trip ==")
     # small demo using existing functions
@@ -131,13 +145,65 @@ def run_rsa():
         print("ERROR: RSA round-trip failed.")
     line()
 
-def run_dh():
+def run_rsa(run_default: bool = False):
+    if run_default:
+        _run_rsa_demo()
+        return
+
+    while True:
+        line()
+        print("== RSA Menu ==")
+        print("  1) Run RSA round-trip demo")
+        print("  2) Encrypt to file")
+        print("  3) Decrypt from file")
+        print("  0) Back")
+        choice = input("Select an option: ").strip().lower()
+        if choice == "1":
+            _run_rsa_demo()
+        elif choice == "2":
+            run_rsa_encrypt_console()
+        elif choice == "3":
+            run_rsa_decrypt_console()
+        elif choice == "0" or choice in {"q", "quit", "exit"}:
+            line()
+            break
+        else:
+            print("Invalid option. Choose 0-3.")
+
+
+def _run_dh_demo():
     line()
     print("== Diffie–Hellman (finite field) ==")
     dh_demo()
     line()
 
-def run_ecdh():
+def run_dh(run_default: bool = False):
+    if run_default:
+        _run_dh_demo()
+        return
+
+    while True:
+        line()
+        print("== DH Menu ==")
+        print("  1) Run DH demo")
+        print("  2) Encrypt to file")
+        print("  3) Decrypt from file")
+        print("  0) Back")
+        choice = input("Select an option: ").strip().lower()
+        if choice == "1":
+            _run_dh_demo()
+        elif choice == "2":
+            run_dh_encrypt_console()
+        elif choice == "3":
+            run_dh_decrypt_console()
+        elif choice == "0" or choice in {"q", "quit", "exit"}:
+            line()
+            break
+        else:
+            print("Invalid option. Choose 0-3.")
+
+
+def _run_ecdh_demo():
     line()
     print("== ECDH (tinyec) ==")
     if ecdh_demo is None:
@@ -147,6 +213,38 @@ def run_ecdh():
     else:
         ecdh_demo()
     line()
+
+
+def run_ecdh(run_default: bool = False):
+    if run_default:
+        _run_ecdh_demo()
+        return
+
+    while True:
+        line()
+        print("== ECDH Menu ==")
+        print("  1) Run ECDH demo")
+        print("  2) Encrypt to file")
+        print("  3) Decrypt from file")
+        print("  0) Back")
+        choice = input("Select an option: ").strip().lower()
+        if choice == "1":
+            _run_ecdh_demo()
+        elif choice == "2":
+            if run_ecdh_encrypt_console is None:
+                print("ECDH file helpers unavailable. Import failed.")
+            else:
+                run_ecdh_encrypt_console()
+        elif choice == "3":
+            if run_ecdh_decrypt_console is None:
+                print("ECDH file helpers unavailable. Import failed.")
+            else:
+                run_ecdh_decrypt_console()
+        elif choice == "0" or choice in {"q", "quit", "exit"}:
+            line()
+            break
+        else:
+            print("Invalid option. Choose 0-3.")
 
 def run_bleichenbacher():
     line()
@@ -160,9 +258,9 @@ def run_bleichenbacher():
 
 def run_all():
     run_aes(run_default=True)
-    run_rsa()
-    run_dh()
-    run_ecdh()
+    run_rsa(run_default=True)
+    run_dh(run_default=True)
+    run_ecdh(run_default=True)
     run_bleichenbacher()
     print("All demos completed.")
 

--- a/rsa/rsa_file_io.py
+++ b/rsa/rsa_file_io.py
@@ -1,0 +1,296 @@
+"""Helper utilities for RSA file-based encryption using raw textbook RSA."""
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Tuple
+
+from rsa.rsa_from_scratch import (
+    generate_key,
+    encrypt_int,
+    decrypt_int,
+)
+
+
+@dataclass(frozen=True)
+class RsaPublicKey:
+    n: int
+    e: int
+
+
+@dataclass(frozen=True)
+class RsaPrivateKey:
+    n: int
+    d: int
+
+
+class MissingPrivateKeyError(ValueError):
+    """Raised when the RSA private exponent is required but unavailable."""
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def _b64decode(value: str, *, field: str) -> bytes:
+    try:
+        return base64.b64decode(value, validate=True)
+    except Exception as exc:  # binascii.Error, ValueError
+        raise ValueError(f"Invalid base64 value for '{field}'") from exc
+
+
+def _ensure_bytes(data: bytes | bytearray | memoryview) -> bytes:
+    if not isinstance(data, (bytes, bytearray, memoryview)):
+        raise TypeError("plaintext must be bytes-like")
+    return bytes(data)
+
+
+def _int_to_bytes(value: int, length: int) -> bytes:
+    return value.to_bytes(length, "big")
+
+
+def _bytes_to_int(data: bytes) -> int:
+    return int.from_bytes(data, "big")
+
+
+def _parse_int(value: str, *, field: str) -> int:
+    text = value.strip().lower()
+    if text.startswith("0x"):
+        base = 16
+        text = text[2:]
+    else:
+        base = 10
+    try:
+        return int(text, base)
+    except ValueError as exc:
+        raise ValueError(f"Invalid integer for {field}") from exc
+
+
+def encrypt_to_file(
+    plaintext: bytes | bytearray | memoryview,
+    out_path: str | Path,
+    *,
+    public_key: RsaPublicKey | None = None,
+    key_bits: int = 1024,
+    store_private: bool = False,
+) -> Tuple[RsaPublicKey, RsaPrivateKey | None]:
+    """Encrypt *plaintext* with RSA and persist as JSON."""
+
+    message = _ensure_bytes(plaintext)
+
+    if public_key is None:
+        n, e, d = generate_key(key_bits)
+        public_key = RsaPublicKey(n=n, e=e)
+        private_key = RsaPrivateKey(n=n, d=d)
+    else:
+        n = public_key.n
+        e = public_key.e
+        private_key = None
+        if store_private:
+            raise ValueError("store_private=True requires a generated key pair")
+
+    modulus_bytes = (public_key.n.bit_length() + 7) // 8
+    if len(message) >= modulus_bytes:
+        raise ValueError("Plaintext too large for modulus (no padding used)")
+
+    m_int = _bytes_to_int(message)
+    c_int = encrypt_int(m_int, public_key.e, public_key.n)
+    ciphertext_bytes = _int_to_bytes(c_int, modulus_bytes)
+
+    bundle: dict[str, Any] = {
+        "alg": "RSA",
+        "v": 1,
+        "n": str(public_key.n),
+        "e": public_key.e,
+        "modulus_bytes": modulus_bytes,
+        "plaintext_len": len(message),
+        "ciphertext_b64": _b64encode(ciphertext_bytes),
+    }
+
+    if store_private and private_key is not None:
+        bundle["d"] = str(private_key.d)
+
+    output_path = Path(out_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(bundle, indent=2) + "\n")
+
+    return public_key, private_key
+
+
+def decrypt_from_file(
+    in_path: str | Path,
+    *,
+    private_key: RsaPrivateKey | None = None,
+) -> bytes:
+    """Decrypt a JSON RSA bundle and return the plaintext."""
+
+    path = Path(in_path)
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"File not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError("Input file is not valid JSON") from exc
+
+    if data.get("alg") != "RSA":
+        raise ValueError("Input file does not contain RSA data")
+
+    try:
+        n = int(data["n"])
+        e = int(data["e"])
+        modulus_bytes = int(data["modulus_bytes"])
+        plaintext_len = int(data["plaintext_len"])
+    except KeyError as exc:
+        raise ValueError(f"Missing required RSA field: {exc.args[0]}") from exc
+    except ValueError as exc:
+        raise ValueError("RSA metadata contains invalid integers") from exc
+
+    key_in_file = data.get("d")
+    if private_key is None:
+        if key_in_file is None:
+            raise MissingPrivateKeyError(
+                "RSA private exponent required but not provided and not stored in file."
+            )
+        private_key = RsaPrivateKey(n=n, d=int(key_in_file))
+    elif private_key.n == 0:
+        private_key = RsaPrivateKey(n=n, d=private_key.d)
+    elif private_key.n != n:
+        raise ValueError("Provided private key does not match modulus in file")
+
+    ciphertext_b64 = data.get("ciphertext_b64")
+    if not ciphertext_b64:
+        raise ValueError("Missing ciphertext in RSA file")
+    ciphertext = _b64decode(ciphertext_b64, field="ciphertext_b64")
+    if len(ciphertext) != modulus_bytes:
+        raise ValueError("Ciphertext length does not match recorded modulus bytes")
+
+    c_int = _bytes_to_int(ciphertext)
+    m_int = decrypt_int(c_int, private_key.d, private_key.n)
+    plaintext_padded = _int_to_bytes(m_int, modulus_bytes)
+    if plaintext_len > len(plaintext_padded):
+        raise ValueError("Recorded plaintext length larger than recovered data")
+    return plaintext_padded[-plaintext_len:]
+
+
+def run_encrypt_console() -> None:
+    """Interactive prompt for RSA encryption to a JSON file."""
+
+    print("-- RSA Encrypt to File --")
+    plaintext_str = input("Enter plaintext: ")
+    plaintext = plaintext_str.encode("utf-8")
+
+    key_bits_str = input("Key size in bits (default 1024): ").strip()
+    key_bits = 1024
+    if key_bits_str:
+        try:
+            key_bits = int(key_bits_str)
+        except ValueError:
+            print("Invalid key size; using 1024 bits.")
+            key_bits = 1024
+        if key_bits < 256:
+            print("Key size too small; using minimum 256 bits.")
+            key_bits = max(256, key_bits)
+
+    store_private_answer = input("Store private exponent in file? (y/N): ").strip().lower()
+    store_private = store_private_answer in {"y", "yes"}
+
+    output_dir = Path("EncryptedFiles") / "RSA"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    name_hint = input("Name for output file (optional): ").strip()
+    if not name_hint:
+        name_hint = "rsa"
+    sanitized = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in name_hint)
+    if not sanitized:
+        sanitized = "rsa"
+
+    from datetime import datetime
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_file = output_dir / f"{sanitized}_{timestamp}.json"
+
+    try:
+        public_key, private_key = encrypt_to_file(
+            plaintext,
+            out_file,
+            key_bits=key_bits,
+            store_private=store_private,
+        )
+    except Exception as exc:
+        print(f"Encryption failed: {exc}")
+        return
+
+    print("RSA encrypted data saved to:")
+    print(f"  {out_file.resolve()}")
+    print("Public key (hex):")
+    print(f"  n = {public_key.n:#x}")
+    print(f"  e = {public_key.e:#x}")
+
+    if not store_private and private_key is not None:
+        print("Private exponent (hex) — keep this safe:")
+        print(f"  d = {private_key.d:#x}")
+
+
+def run_decrypt_console() -> None:
+    """Interactive prompt for RSA decryption from a JSON file."""
+
+    print("-- RSA Decrypt from File --")
+    encrypted_dir = Path("EncryptedFiles") / "RSA"
+    if not encrypted_dir.exists():
+        print("No RSA encrypted files found.")
+        return
+
+    files = sorted(file for file in encrypted_dir.iterdir() if file.suffix == ".json")
+    if not files:
+        print("No RSA JSON files available.")
+        return
+
+    print("Available RSA files:")
+    for idx, file in enumerate(files, start=1):
+        print(f"  {idx}) {file.name}")
+
+    while True:
+        selection = input("Select a file number to decrypt (or 'q' to cancel): ").strip()
+        if selection.lower() in {"q", "quit", "exit", "0"}:
+            print("Decryption cancelled.")
+            return
+        try:
+            choice = int(selection)
+        except ValueError:
+            print("Invalid selection. Enter a number or 'q'.")
+            continue
+        if not 1 <= choice <= len(files):
+            print("Selection out of range. Try again.")
+            continue
+        in_file = files[choice - 1]
+        break
+
+    try:
+        plaintext = decrypt_from_file(in_file)
+    except MissingPrivateKeyError:
+        key_input = input("Private exponent not in file. Enter d (decimal or 0x-hex): ").strip()
+        if not key_input:
+            print("No private key provided. Aborting.")
+            return
+        try:
+            d_value = _parse_int(key_input, field="private exponent")
+        except ValueError as exc:
+            print(str(exc))
+            return
+        try:
+            plaintext = decrypt_from_file(in_file, private_key=RsaPrivateKey(n=0, d=d_value))
+        except ValueError as exc:
+            print(f"Decryption failed: {exc}")
+            return
+    except Exception as exc:
+        print(f"Decryption failed: {exc}")
+        return
+
+    try:
+        decoded = plaintext.decode("utf-8")
+    except UnicodeDecodeError:
+        decoded = plaintext.decode("utf-8", errors="replace")
+    print("Recovered plaintext:")
+    print(decoded)


### PR DESCRIPTION
## Summary
- add RSA JSON bundle helpers and expose interactive file encrypt/decrypt workflow via the CLI
- derive AES-GCM keys from DH and ECDH exchanges to provide matching file helpers and CLI options
- update the README to document the new RSA, DH, and ECDH file-encryption capabilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e16e641ef483208463e4654076931b