### PR TITLE
Render CLI banner with pyfiglet

### DIFF
--- a/lab2_cli.py
+++ b/lab2_cli.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import argparse
 import textwrap
 
+import pyfiglet
+
 # --- Imports from your repo modules (ensure you run from repo root) ---
 # AES demos (functions already exist in aes_modes/ecb_cbc_gcm.py)
 from aes_modes.ecb_cbc_gcm import (
@@ -66,15 +68,7 @@ try:
 except Exception:
     bleichenbacher_demo = None
 
-BANNER = r"""
-  _          _        __     ___  
- | |        | |       \ \   / / | 
- | |     ___| |__   ___\ \_/ /| | 
- | |    / __| '_ \ / _ \\   / | | 
- | |____\__ \ | | |  __/ | |  | | 
- |______|___/_| |_|\___| |_|  |_|   Lab 2 — Crypto Demos
-
-"""
+BANNER = pyfiglet.figlet_format("Lab2 - Crypto Demos")
 
 def line():
     print("-" * 70)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pycryptodome
 tinyec
 matplotlib
+pyfiglet


### PR DESCRIPTION
## Summary
- render the CLI banner using pyfiglet so it spells "Lab2 - Crypto Demos"
- add pyfiglet to the Python requirements list for installation

## Testing
- python lab2_cli.py --help *(fails: pyfiglet not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e24d194b2483208fe9b0d34c760f07