### PR TITLE
Fix Miller-Rabin witnesses and ensure RSA helpers present

### DIFF
--- a/rsa/rsa_from_scratch.py
+++ b/rsa/rsa_from_scratch.py
@@ -1,4 +1,3 @@
-import random
 import secrets
 
 def egcd(a: int, b: int):
@@ -14,23 +13,31 @@ def inv_mod(a: int, m: int) -> int:
     return x % m
 
 def miller_rabin(n: int, k: int = 40) -> bool:
+    """Probabilistic primality test using the Miller-Rabin algorithm."""
+
     if n < 2:
         return False
+
     small_primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
     for p in small_primes:
         if n == p:
             return True
         if n % p == 0:
             return False
+
+    if n % 2 == 0:
+        return False
+
     d = n - 1
     r = 0
     while d % 2 == 0:
         d //= 2
         r += 1
+
     for _ in range(k):
-        a = random.randrange(2, n - 2)
+        a = secrets.randbelow(n - 3) + 2
         x = pow(a, d, n)
-        if x == 1 or x == n - 1:
+        if x in (1, n - 1):
             continue
         for _ in range(r - 1):
             x = pow(x, 2, n)


### PR DESCRIPTION
## Summary
- replace the Miller-Rabin witness selection with the `secrets` module for cryptographically strong randomness
- harden the primality test by handling even composites explicitly and document the routine
- ensure the RSA helper functions remain available so the script can run end-to-end

## Testing
- python rsa/rsa_from_scratch.py

------
https://chatgpt.com/codex/tasks/task_e_68e256d4b2688320bd957b554102db68