### PR TITLE
Use cryptographically secure witnesses in Miller-Rabin

### DIFF
--- a/rsa/rsa_from_scratch.py
+++ b/rsa/rsa_from_scratch.py
@@ -1,4 +1,3 @@
-import random
 import secrets
 
 def egcd(a: int, b: int):
@@ -28,7 +27,7 @@ def miller_rabin(n: int, k: int = 40) -> bool:
         d //= 2
         r += 1
     for _ in range(k):
-        a = random.randrange(2, n - 2)
+        a = secrets.randbelow(n - 3) + 2
         x = pow(a, d, n)
         if x == 1 or x == n - 1:
             continue


### PR DESCRIPTION
## Summary
- replace the Miller-Rabin witness selection with `secrets.randbelow` to rely on CSPRNG primitives

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e256f7943c83208f5ba5cfba29148b