### PR TITLE
Clarify GCM nonce uniqueness guidance

### DIFF
--- a/aes_modes/ecb_cbc_gcm.py
+++ b/aes_modes/ecb_cbc_gcm.py
@@ -135,6 +135,8 @@ def roundtrip_checks():
 
 def demo_gcm_keystream_reuse_xor_leak():
     key = get_random_bytes(16)
+    # Real deployments must keep each GCM nonce unique per key—use a
+    # monotonic counter or collision-checked randomness instead of this demo.
     nonce = get_random_bytes(12)  # BAD: reused nonce
     # Construct messages: identical except a middle slice differs
     prefix = b"A" * 32


### PR DESCRIPTION
## Summary
- add an explicit reminder in the GCM misuse demo that nonces must be unique per key
- suggest practical approaches such as monotonic counters or collision-checked randomness

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2570905f483208bcfddb3f1a635e2