### PR TITLE
Add validation for DH peer values and ECDH public points

### DIFF
--- a/dh/dh_small_prime.py
+++ b/dh/dh_small_prime.py
@@ -3,8 +3,15 @@ import secrets
 p = 208351617316091241234326746312124448251235562226470491514186331217050270460481
 g = 2
 
+__all__ = [
+    "p",
+    "g",
+    "validate_public_component",
+    "derive_shared_secret",
+]
 
-def _validate_public_component(component: int, modulus: int) -> None:
+
+def validate_public_component(component: int, modulus: int) -> None:
     """Basic peer validation before Diffie–Hellman exponentiation."""
 
     if not isinstance(component, int):
@@ -14,10 +21,10 @@ def _validate_public_component(component: int, modulus: int) -> None:
         raise ValueError("Peer public component is out of the valid range (1, p-1).")
 
 
-def _derive_shared_secret(private_key: int, peer_public: int, modulus: int) -> int:
+def derive_shared_secret(private_key: int, peer_public: int, modulus: int) -> int:
     """Derive the shared secret after validating the peer's public contribution."""
 
-    _validate_public_component(peer_public, modulus)
+    validate_public_component(peer_public, modulus)
     return pow(peer_public, private_key, modulus)
 
 
@@ -26,10 +33,10 @@ def demo():
     b = secrets.randbelow(p - 2) + 1
     A = pow(g, a, p)
     B = pow(g, b, p)
-    _validate_public_component(A, p)
-    _validate_public_component(B, p)
-    s1 = _derive_shared_secret(a, B, p)
-    s2 = _derive_shared_secret(b, A, p)
+    validate_public_component(A, p)
+    validate_public_component(B, p)
+    s1 = derive_shared_secret(a, B, p)
+    s2 = derive_shared_secret(b, A, p)
     assert s1 == s2
     print("DH shared secret established with peer input validation.")
 

--- a/ecdh/ecdh_file_io.py
+++ b/ecdh/ecdh_file_io.py
@@ -13,6 +13,8 @@ from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
 from tinyec import registry
 
+from ecdh.ecdh_tinyec import validate_public_point
+
 
 @dataclass(frozen=True)
 class EcdhPrivate:
@@ -63,6 +65,8 @@ def encrypt_to_file(
     dB = randbelow(n - 1) + 1
     QA = dA * curve.g
     QB = dB * curve.g
+    validate_public_point(QA, curve)
+    validate_public_point(QB, curve)
     shared = dA * QB
 
     key = _derive_key(curve, shared)
@@ -143,6 +147,9 @@ def decrypt_from_file(
     # reconstruct points
     QA_point = curve.point(QA[0], QA[1])
     QB_point = curve.point(QB[0], QB[1])
+
+    validate_public_point(QA_point, curve)
+    validate_public_point(QB_point, curve)
 
     shared = private_scalar.value * QB_point
     key = _derive_key(curve, shared)

--- a/ecdh/ecdh_tinyec.py
+++ b/ecdh/ecdh_tinyec.py
@@ -6,6 +6,10 @@ from typing import Iterable, Tuple
 import matplotlib.pyplot as plt
 from tinyec import ec, registry
 
+__all__ = [
+    "validate_public_point",
+]
+
 
 def _normalise_point(point, modulus: int) -> Tuple[float, float]:
     """Project a point in the finite field onto [0, 1] for plotting."""
@@ -66,7 +70,7 @@ def _plot_key_exchange(curve, qa, qb, shared_point) -> None:
     ax.legend()
 
 
-def _validate_public_point(point, curve) -> None:
+def validate_public_point(point, curve) -> None:
     """Validate a peer's public point before using it in ECDH."""
 
     if isinstance(point, ec.Inf) or point is None:
@@ -93,8 +97,8 @@ def demo():
     dB = secrets.randbelow(n - 1) + 1
     QA = dA * curve.g
     QB = dB * curve.g
-    _validate_public_point(QA, curve)
-    _validate_public_point(QB, curve)
+    validate_public_point(QA, curve)
+    validate_public_point(QB, curve)
     S1 = dA * QB
     S2 = dB * QA
     assert S1.x == S2.x and S1.y == S2.y


### PR DESCRIPTION
## Summary
- expose reusable Diffie–Hellman validation helpers and enforce them in file IO workflows
- reuse the tinyec point validator across modules to reject malformed ECDH public keys before computing shared secrets

## Testing
- `python -m compileall dh ecdh`


------
https://chatgpt.com/codex/tasks/task_e_68e25ba2ea7083208ec083d05dc17de2