### PR TITLE
Clear CLI screen before showing banner

### DIFF
--- a/lab2_cli.py
+++ b/lab2_cli.py
@@ -18,6 +18,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import pathlib
 import sys
 import textwrap
@@ -74,10 +75,22 @@ except Exception:
 
 BANNER = pyfiglet.figlet_format("Lab2 - Crypto Demos")
 
+
+def clear_screen() -> None:
+    """Clear the terminal screen in a cross-platform way."""
+    command = "cls" if os.name == "nt" else "clear"
+    try:
+        os.system(command)
+    except Exception:
+        # Ignore failures so the CLI still works even if the command is missing.
+        pass
+
+
 def line():
     print("-" * 70)
 
 def menu():
+    clear_screen()
     print(BANNER)
     print("Choose a demo/task to run:")
     print("  1) AES demos (ECB/CBC/GCM + misuse)")


### PR DESCRIPTION
## Summary
- add a helper to clear the terminal screen
- clear the display before rendering the interactive menu banner

## Testing
- python -m compileall lab2_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e277469f10832085f5dbfc524cf1eb