### PR TITLE
Add pause after running all demos

### DIFF
--- a/lab2_cli.py
+++ b/lab2_cli.py
@@ -314,13 +314,15 @@ def run_bleichenbacher(run_default: bool = False, fast_default: bool = True):
         else:
             print("Invalid choice. Please try again.\n")
 
-def run_all():
+def run_all(wait_for_key: bool = False):
     run_aes(run_default=True)
     run_rsa(run_default=True)
     run_dh(run_default=True)
     run_ecdh(run_default=True)
     run_bleichenbacher(run_default=True, fast_default=True)
     print("All demos completed.")
+    if wait_for_key:
+        input("\nPress Enter to return to the main menu...")
 
 def parse_args():
     ap = argparse.ArgumentParser(
@@ -368,7 +370,7 @@ def main():
         elif choice == "5":
             run_bleichenbacher()
         elif choice == "6":
-            run_all()
+            run_all(wait_for_key=True)
         elif choice == "0" or choice.lower() in {"q", "quit", "exit"}:
             print("Goodbye!")
             break


### PR DESCRIPTION
## Summary
- update the `run_all` helper to optionally pause before returning
- wait for user input after demo 6 completes in the interactive menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27e2ad7e88320adf0b0cf62a4b138