### PR TITLE
Add smoke tests and helper utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ python lab2_cli.py --run dh
 python lab2_cli.py --run ecdh
 python lab2_cli.py --run bleichenbacher
 python lab2_cli.py --run all
+pytest          # run the smoke-test suite
 ```
 
 ### Run modules directly (optional)

--- a/dh/dh_small_prime.py
+++ b/dh/dh_small_prime.py
@@ -1,3 +1,4 @@
+import hashlib
 import secrets
 
 p = 208351617316091241234326746312124448251235562226470491514186331217050270460481
@@ -28,7 +29,7 @@ def derive_shared_secret(private_key: int, peer_public: int, modulus: int) -> in
     return pow(peer_public, private_key, modulus)
 
 
-def demo():
+def _demo_exchange():
     a = secrets.randbelow(p - 2) + 1
     b = secrets.randbelow(p - 2) + 1
     A = pow(g, a, p)
@@ -37,13 +38,40 @@ def demo():
     validate_public_component(B, p)
     s1 = derive_shared_secret(a, B, p)
     s2 = derive_shared_secret(b, A, p)
-    assert s1 == s2
+    return {
+        "a": a,
+        "b": b,
+        "A": A,
+        "B": B,
+        "shared_a": s1,
+        "shared_b": s2,
+    }
+
+
+def dh_demo():
+    """Return matching SHA-256 digests of the DH shared secret."""
+
+    values = _demo_exchange()
+    shared_a = values["shared_a"]
+    shared_b = values["shared_b"]
+    assert shared_a == shared_b
+    k = (p.bit_length() + 7) // 8
+    digest_a = hashlib.sha256(shared_a.to_bytes(k, "big")).hexdigest()
+    digest_b = hashlib.sha256(shared_b.to_bytes(k, "big")).hexdigest()
+    return digest_a, digest_b
+
+
+def demo():
+    values = _demo_exchange()
+    shared_a = values["shared_a"]
+    shared_b = values["shared_b"]
+    assert shared_a == shared_b
     print(f"p (modulus) bits: {p.bit_length()} | generator g: {g}")
-    print(f"Alice private a: 0x{a:x}")
-    print(f"Bob private b: 0x{b:x}")
-    print(f"Alice public A = g^a mod p: 0x{A:x}")
-    print(f"Bob public B = g^b mod p: 0x{B:x}")
-    shared_hex = hex(s1)[2:66] + ("…" if s1.bit_length() > 256 else "")
+    print(f"Alice private a: 0x{values['a']:x}")
+    print(f"Bob private b: 0x{values['b']:x}")
+    print(f"Alice public A = g^a mod p: 0x{values['A']:x}")
+    print(f"Bob public B = g^b mod p: 0x{values['B']:x}")
+    shared_hex = hex(shared_a)[2:66] + ("…" if shared_a.bit_length() > 256 else "")
     print(f"Shared secret (head): 0x{shared_hex}")
     print("DH shared secret established with peer input validation.")
 

--- a/ecdh/ecdh_tinyec.py
+++ b/ecdh/ecdh_tinyec.py
@@ -8,7 +8,7 @@ from typing import Iterable, Tuple
 import matplotlib.pyplot as plt
 from tinyec import ec, registry
 
-__all__ = ["validate_public_point"]
+__all__ = ["validate_public_point", "ecdh_demo"]
 
 
 # -------- helpers --------
@@ -123,7 +123,7 @@ def _sanity_checks(curve, dA, dB, QA, QB, S1, S2):
 
 # -------- demo --------
 
-def demo():
+def _demo_keys():
     curve = registry.get_curve("secp256r1")
     n = curve.field.n
 
@@ -143,6 +143,20 @@ def demo():
 
     S1 = dA * QB
     S2 = dB * QA
+    return curve, dA, dB, QA, QB, S1, S2
+
+
+def ecdh_demo() -> str:
+    """Return the SHA-256 digest of the ECDH shared point's x-coordinate."""
+
+    curve, dA, dB, QA, QB, S1, S2 = _demo_keys()
+    _sanity_checks(curve, dA, dB, QA, QB, S1, S2)
+    digest = hashlib.sha256(_x_bytes(curve, S1)).hexdigest()
+    return digest
+
+
+def demo():
+    curve, dA, dB, QA, QB, S1, S2 = _demo_keys()
     _sanity_checks(curve, dA, dB, QA, QB, S1, S2)
     modulus_bits = curve.field.p.bit_length()
     print(f"[ECDH] Curve: {curve.name} (p={modulus_bits} bits)")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -q

--- a/rsa/rsa_from_scratch.py
+++ b/rsa/rsa_from_scratch.py
@@ -1,4 +1,5 @@
 import secrets
+from typing import Tuple
 
 def egcd(a: int, b: int):
     if b == 0:
@@ -119,13 +120,31 @@ def encrypt_int(m: int, e: int, n: int) -> int:
 def decrypt_int(c: int, d: int, n: int) -> int:
     return pow(c, d, n)
 
-if __name__ == "__main__":
-    print("== RSA from scratch ==")
-    n, e, d = generate_key(1024)
+
+def rsa_roundtrip(bits: int = 512) -> Tuple[int, int, int, bool]:
+    """Generate a small RSA key and perform an encrypt/decrypt round-trip.
+
+    Returns the key parameters together with a boolean indicating whether the
+    decrypted plaintext matches the original message.  The helper keeps the
+    key size modest so smoke tests run quickly while still exercising the
+    number-theory utilities.
+    """
+
+    n, e, d = generate_key(bits)
     msg = b"hi rsa"
     m = i2osp(msg)
     c = encrypt_int(m, e, n)
     dec = decrypt_int(c, d, n)
     out = os2ip(dec)
-    assert out == msg, "Roundtrip failed"
+    return n, e, d, out == msg
+
+if __name__ == "__main__":
+    print("== RSA from scratch ==")
+    n, e, d, ok = rsa_roundtrip(1024)
+    msg = b"hi rsa"
+    m = i2osp(msg)
+    c = encrypt_int(m, e, n)
+    dec = decrypt_int(c, d, n)
+    out = os2ip(dec)
+    assert ok and out == msg, "Roundtrip failed"
     print(f"n bits: {n.bit_length()}, e: {e}, ok = {out == msg}")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,45 @@
+import os
+import pathlib
+import sys
+
+# Ensure matplotlib uses a non-interactive backend for headless test runs.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_aes_roundtrip():
+    from aes_modes.ecb_cbc_gcm import roundtrip_demo
+
+    res = roundtrip_demo()
+    assert res["ok_ecb"] and res["ok_cbc"] and res["ok_gcm"]
+
+
+def test_dh_shared_secret():
+    from dh.dh_small_prime import dh_demo
+
+    sha_a, sha_b = dh_demo()
+    assert sha_a == sha_b
+
+
+def test_ecdh_shared_secret():
+    from ecdh.ecdh_tinyec import ecdh_demo
+
+    digest = ecdh_demo()
+    assert isinstance(digest, str) and len(digest) == 64
+
+
+def test_rsa_roundtrip():
+    from rsa.rsa_from_scratch import rsa_roundtrip
+
+    n, e, d, ok = rsa_roundtrip()
+    assert ok and all(isinstance(value, int) for value in (n, e, d))
+
+
+def test_bleichenbacher_fast_oracle():
+    from attacks.bleichenbacher_oracle import demo_fast_oracle
+
+    ok, iters = demo_fast_oracle()
+    assert ok and iters > 0


### PR DESCRIPTION
## Summary
- add pytest-based smoke tests with a quiet default configuration
- expose helper functions in the demos so tests can assert on round-trip results
- document running the smoke tests via `pytest`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e28bb5dc0c83209674d8ef86f37611