### PR TITLE
Prevent Tkinter cleanup warnings in ECDH demo

### DIFF
--- a/ecdh/ecdh_tinyec.py
+++ b/ecdh/ecdh_tinyec.py
@@ -1,5 +1,6 @@
 """ECDH demonstration using tinyec with visualisations of key steps."""
 
+import atexit
 import hashlib
 import os
 import secrets
@@ -9,6 +10,12 @@ import matplotlib.pyplot as plt
 from tinyec import ec, registry
 
 __all__ = ["validate_public_point", "ecdh_demo"]
+
+
+# Close any open matplotlib figures before the interpreter exits to avoid
+# Tkinter "can't delete Tcl command" warnings on some platforms (notably
+# Windows with the TkAgg backend) when running the demos non-interactively.
+atexit.register(lambda: plt.close("all"))
 
 
 # -------- helpers --------


### PR DESCRIPTION
## Summary
- register an atexit handler in the ECDH demo to close any matplotlib figures before shutdown
- avoid Tkinter "can't delete Tcl command" warnings when running the CLI non-interactively

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e28dab75e08320ac2f92a744f4c629