### PR TITLE
Add CBC bit-flip regression test and visualize GCM leakage

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -17,6 +17,37 @@ def test_aes_roundtrip():
     assert res["ok_ecb"] and res["ok_cbc"] and res["ok_gcm"]
 
 
+def test_cbc_bitflip_corrupts_first_block():
+    from aes_modes.ecb_cbc_gcm import aes_cbc_decrypt, aes_cbc_encrypt, BLOCK
+
+    key = bytes.fromhex("00112233445566778899aabbccddeeff")
+    pt = b"A" * BLOCK + b"B" * BLOCK
+
+    iv_ct = aes_cbc_encrypt(key, pt)
+    assert aes_cbc_decrypt(key, iv_ct) == pt
+
+    original_iv = iv_ct[:BLOCK]
+    ciphertext_body = iv_ct[BLOCK:]
+
+    tampered_iv = bytearray(original_iv)
+    tampered_iv[0] ^= 0x01
+
+    tampered_plaintext = aes_cbc_decrypt(key, bytes(tampered_iv) + ciphertext_body)
+
+    assert tampered_plaintext[:BLOCK] != pt[:BLOCK]
+    assert tampered_plaintext[BLOCK:] == pt[BLOCK:]
+
+
+def test_gcm_keystream_visualization(tmp_path):
+    from aes_modes.ecb_cbc_gcm import demo_gcm_keystream_reuse_xor_leak
+
+    out = demo_gcm_keystream_reuse_xor_leak(save_path=tmp_path / "reuse.png")
+
+    assert out["leak_hex"] == out["expected_hex"]
+    assert out["recovered_mid"] == out["expected_mid"]
+    assert (tmp_path / "reuse.png").exists()
+
+
 def test_dh_shared_secret():
     from dh.dh_small_prime import dh_demo
 


### PR DESCRIPTION
## Summary
- add an automated CBC bit-flip regression test that asserts plaintext corruption when the IV is tampered
- enhance the GCM keystream reuse demo to generate a saved heatmap visualization and expose structured data for assertions
- cover the visualization with a smoke test to ensure the leak metrics and recovered plaintext agree with expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e298cf1230832094e32bb9664fe31f