### PR TITLE
Improve AES demos testability and randomness handling

### DIFF
--- a/aes_modes/ecb_cbc_gcm.py
+++ b/aes_modes/ecb_cbc_gcm.py
@@ -1,5 +1,5 @@
 import base64
-import os
+import secrets
 
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
@@ -53,30 +53,45 @@ def aes_gcm_decrypt(key: bytes, nonce: bytes, ct: bytes, tag: bytes, aad: bytes 
     cipher.update(aad)
     return cipher.decrypt_and_verify(ct, tag)
 
-def demo_ecb_pattern_leakage():
+def demo_ecb_pattern_leakage(*, verbose: bool = True):
+    """Show ECB block repetition and return the artefacts for testing."""
+
     key = get_random_bytes(16)
     block = b"A" * 16
     pt = block * 4 + b"B" * 16 + block * 3
     ct = aes_ecb_encrypt(key, pt)
     blocks = [ct[i:i + 16] for i in range(0, len(ct), 16)]
     unique_blocks = len(set(blocks))
-    print("[ECB] Key:", key.hex())
-    print(f"[ECB] Total blocks: {len(blocks)}, unique blocks: {unique_blocks} (lower is worse)")
-    print("[ECB] Ciphertext block pattern:")
-    for idx, block_bytes in enumerate(blocks, start=1):
-        marker = "*" if blocks.count(block_bytes) > 1 else " "
-        print(f"    Block {idx:02d}{marker}: {block_bytes.hex()}")
-    print("[ECB] Repeated blocks (marked with * ) reveal the repeated plaintext pattern.")
+    result = {
+        "key": key,
+        "ciphertext_blocks": blocks,
+        "unique_blocks": unique_blocks,
+    }
 
-def demo_cbc_iv_reuse():
+    if verbose:
+        print("[ECB] Key:", key.hex())
+        print(
+            f"[ECB] Total blocks: {len(blocks)}, unique blocks: {unique_blocks} (lower is worse)"
+        )
+        print("[ECB] Ciphertext block pattern:")
+        for idx, block_bytes in enumerate(blocks, start=1):
+            marker = "*" if blocks.count(block_bytes) > 1 else " "
+            print(f"    Block {idx:02d}{marker}: {block_bytes.hex()}")
+        print("[ECB] Repeated blocks (marked with * ) reveal the repeated plaintext pattern.")
+
+    return result
+
+def demo_cbc_iv_reuse(*, verbose: bool = True):
+    """Demonstrate CBC IV reuse leakage and return the computed values."""
+
     key = get_random_bytes(16)
     iv = get_random_bytes(BLOCK)
 
     # Two plaintexts that share the same first block but diverge afterwards.
     shared_block = b"shared prefix bl"
     assert len(shared_block) == BLOCK
-    p1 = shared_block + b"ock -> amount=100" + os.urandom(5)
-    p2 = shared_block + b"ock -> amount=900" + os.urandom(5)
+    p1 = shared_block + b"ock -> amount=100" + secrets.token_bytes(5)
+    p2 = shared_block + b"ock -> amount=900" + secrets.token_bytes(5)
 
     c1 = aes_cbc_encrypt(key, p1, iv=iv)
     c2 = aes_cbc_encrypt(key, p2, iv=iv)
@@ -86,59 +101,99 @@ def demo_cbc_iv_reuse():
     c1_first_block = c1_body[:BLOCK]
     c2_first_block = c2_body[:BLOCK]
 
-    print("[CBC] Key:", key.hex())
-    print("[CBC] Reused IV:", iv.hex())
-    print(f"[CBC] Reused IV -> identical IV blocks? {c1_iv == c2_iv}")
-    print(f"[CBC] Reused IV -> identical first ciphertext blocks? {c1_first_block == c2_first_block}")
-    print("[CBC] Ciphertext #1 blocks:")
-    for i in range(0, len(c1_body), BLOCK):
-        print(f"    C1[{i//BLOCK:02d}]: {c1_body[i:i+BLOCK].hex()}")
-    print("[CBC] Ciphertext #2 blocks:")
-    for i in range(0, len(c2_body), BLOCK):
-        print(f"    C2[{i//BLOCK:02d}]: {c2_body[i:i+BLOCK].hex()}")
-    print("[CBC] Second ciphertext block differs?", c1_body[BLOCK:2*BLOCK] != c2_body[BLOCK:2*BLOCK])
-
-    # Show the classic leakage equation for CBC with reused IV:
-    # C1[0] ^ C2[0] == P1[0] ^ P2[0]
     p1_first = p1[:BLOCK]
     p2_first = p2[:BLOCK]
     x_c = bytes(a ^ b for a, b in zip(c1_first_block, c2_first_block))
     x_p = bytes(a ^ b for a, b in zip(p1_first, p2_first))
-    print("[CBC] XOR(C1[0], C2[0]) == XOR(P1[0], P2[0]) ?", x_c == x_p)
-    print("[CBC] XOR(C1[0], C2[0]):", x_c.hex())
-    print("[CBC] XOR(P1[0], P2[0]):", x_p.hex())
-
-    # Demonstrate bit-flipping attack on CBC first block via IV tampering
-    # Flip a bit in IV and decrypt c2 under the tampered IV;
-    # the corresponding bit in P2'[0] will flip.
-    from Crypto.Cipher import AES as _AES
 
     tampered_iv = bytearray(c2_iv)
     tampered_iv[0] ^= 0x20  # flip one bit
-    dec = _AES.new(key, _AES.MODE_CBC, iv=bytes(tampered_iv)).decrypt(c2_body)
+    dec = AES.new(key, AES.MODE_CBC, iv=bytes(tampered_iv)).decrypt(c2_body)
     tampered_first_block = dec[:BLOCK]
-    print("[CBC] Bit-flip demo: P2'[0] differs from original P2[0]?", tampered_first_block != p2_first)
-    print("[CBC] Tampered first plaintext block:", tampered_first_block.hex())
-    print("[CBC] Original first plaintext block:", p2_first.hex())
 
-def demo_gcm_nonce_reuse():
+    result = {
+        "key": key,
+        "iv": iv,
+        "plaintexts": (p1, p2),
+        "ciphertexts": (c1, c2),
+        "xor_ciphertexts": x_c,
+        "xor_plaintexts": x_p,
+        "tampered_first_block": tampered_first_block,
+        "original_first_block": p2_first,
+    }
+
+    if verbose:
+        print("[CBC] Key:", key.hex())
+        print("[CBC] Reused IV:", iv.hex())
+        print(f"[CBC] Reused IV -> identical IV blocks? {c1_iv == c2_iv}")
+        print(
+            f"[CBC] Reused IV -> identical first ciphertext blocks? {c1_first_block == c2_first_block}"
+        )
+        print("[CBC] Ciphertext #1 blocks:")
+        for i in range(0, len(c1_body), BLOCK):
+            print(f"    C1[{i//BLOCK:02d}]: {c1_body[i:i+BLOCK].hex()}")
+        print("[CBC] Ciphertext #2 blocks:")
+        for i in range(0, len(c2_body), BLOCK):
+            print(f"    C2[{i//BLOCK:02d}]: {c2_body[i:i+BLOCK].hex()}")
+        print(
+            "[CBC] Second ciphertext block differs?",
+            c1_body[BLOCK:2 * BLOCK] != c2_body[BLOCK:2 * BLOCK],
+        )
+        print("[CBC] XOR(C1[0], C2[0]) == XOR(P1[0], P2[0]) ?", x_c == x_p)
+        print("[CBC] XOR(C1[0], C2[0]):", x_c.hex())
+        print("[CBC] XOR(P1[0], P2[0]):", x_p.hex())
+        print(
+            "[CBC] Bit-flip demo: P2'[0] differs from original P2[0]?",
+            tampered_first_block != p2_first,
+        )
+        print("[CBC] Tampered first plaintext block:", tampered_first_block.hex())
+        print("[CBC] Original first plaintext block:", p2_first.hex())
+
+    return result
+
+def demo_gcm_nonce_reuse(*, verbose: bool = True):
+    """Highlight the dangers of nonce reuse in GCM and return context."""
+
     key = get_random_bytes(16)
     nonce = get_random_bytes(12)
     aad = b"hdr"
     p1 = b"GCM message one"
     p2 = b"GCM message two"
     n1, c1, t1 = aes_gcm_encrypt(key, p1, aad=aad, nonce=nonce)
-    n2, c2, t2 = aes_gcm_encrypt(key, p2, aad=aad, nonce=nonce)
-    print("[GCM] Key:", key.hex())
-    print("[GCM] Nonce (reused):", nonce.hex())
-    print(f"[GCM] Tag #1: {t1.hex()} | Tag #2: {t2.hex()} | tags equal? {t1 == t2}")
-    print("[GCM] Ciphertext #1:", c1.hex())
-    print("[GCM] Ciphertext #2:", c2.hex())
+    _, c2, t2 = aes_gcm_encrypt(key, p2, aad=aad, nonce=nonce)
+
+    wrong_tag_valid = False
+    wrong_tag_error: str | None = None
     try:
-        _ = aes_gcm_decrypt(key, n1, c1, t2, aad=aad)
-        print("[GCM] Unexpectedly verified with wrong tag (should not happen).")
-    except Exception as e:
-        print(f"[GCM] Verification with wrong tag failed as expected: {type(e).__name__}")
+        aes_gcm_decrypt(key, n1, c1, t2, aad=aad)
+        wrong_tag_valid = True
+    except Exception as exc:  # pragma: no cover - exercised via bool
+        wrong_tag_error = type(exc).__name__
+
+    result = {
+        "key": key,
+        "nonce": nonce,
+        "aad": aad,
+        "ciphertexts": (c1, c2),
+        "tags": (t1, t2),
+        "wrong_tag_valid": wrong_tag_valid,
+        "wrong_tag_error": wrong_tag_error,
+    }
+
+    if verbose:
+        print("[GCM] Key:", key.hex())
+        print("[GCM] Nonce (reused):", nonce.hex())
+        print(f"[GCM] Tag #1: {t1.hex()} | Tag #2: {t2.hex()} | tags equal? {t1 == t2}")
+        print("[GCM] Ciphertext #1:", c1.hex())
+        print("[GCM] Ciphertext #2:", c2.hex())
+        if wrong_tag_valid:
+            print("[GCM] Unexpectedly verified with wrong tag (should not happen).")
+        else:
+            print(
+                f"[GCM] Verification with wrong tag failed as expected: {wrong_tag_error}"
+            )
+
+    return result
 
 def roundtrip_demo():
     """Run a short AES round-trip across ECB, CBC and GCM.
@@ -171,23 +226,29 @@ def roundtrip_demo():
     }
 
 
-def roundtrip_checks():
+def roundtrip_checks(*, verbose: bool = True):
+    """Run the AES round-trip demo and optionally print a summary."""
+
     result = roundtrip_demo()
-    key = result["key"]
-    msg = result["plaintext"]
-    cte = result["ecb_ct"]
-    ctc = result["cbc_iv_ct"]
-    nonce = result["gcm_nonce"]
-    tag = result["gcm_tag"]
-    print("[Roundtrip] AES-128 key:", key.hex())
-    print("[Roundtrip] Plaintext length:", len(msg), "bytes")
-    print("[Roundtrip] ECB ciphertext (first 32 hex):", cte[:16].hex())
-    print("[Roundtrip] CBC IV:", ctc[:BLOCK].hex())
-    print("[Roundtrip] GCM nonce:", nonce.hex(), "tag:", tag.hex())
-    print("[Roundtrip] All modes decrypted back to the original message.")
+    if verbose:
+        key = result["key"]
+        msg = result["plaintext"]
+        cte = result["ecb_ct"]
+        ctc = result["cbc_iv_ct"]
+        nonce = result["gcm_nonce"]
+        tag = result["gcm_tag"]
+        print("[Roundtrip] AES-128 key:", key.hex())
+        print("[Roundtrip] Plaintext length:", len(msg), "bytes")
+        print("[Roundtrip] ECB ciphertext (first 32 hex):", cte[:16].hex())
+        print("[Roundtrip] CBC IV:", ctc[:BLOCK].hex())
+        print("[Roundtrip] GCM nonce:", nonce.hex(), "tag:", tag.hex())
+        print("[Roundtrip] All modes decrypted back to the original message.")
+    return result
 
 
-def demo_gcm_keystream_reuse_xor_leak():
+def demo_gcm_keystream_reuse_xor_leak(*, verbose: bool = True):
+    """Return details of GCM keystream reuse while logging optionally."""
+
     key = get_random_bytes(16)
     nonce = get_random_bytes(12)  # BAD: reused nonce
     # Construct messages: identical except a middle slice differs
@@ -199,8 +260,8 @@ def demo_gcm_keystream_reuse_xor_leak():
     p2 = prefix + mid2 + suffix
 
     # Same key + SAME nonce (this is the vulnerability)
-    n1, c1, t1 = aes_gcm_encrypt(key, p1, nonce=nonce)
-    n2, c2, t2 = aes_gcm_encrypt(key, p2, nonce=nonce)
+    _, c1, t1 = aes_gcm_encrypt(key, p1, nonce=nonce)
+    _, c2, t2 = aes_gcm_encrypt(key, p2, nonce=nonce)
 
     # Emulate reading ciphertext bundles from JSON files
     bundle1 = {"ciphertext_b64": base64.b64encode(c1).decode("ascii")}
@@ -211,11 +272,6 @@ def demo_gcm_keystream_reuse_xor_leak():
     # Keystream reuse property in CTR/GCM: C1 ^ C2 = P1 ^ P2
     leak_hex = xor_hex(ct1, ct2)
     expected_hex = xor_hex(p1, p2)
-    print("[GCM] Key:", key.hex())
-    print("[GCM] Nonce reused:", nonce.hex())
-    print("[GCM] Keystream reuse: XOR(c1,c2) == XOR(p1,p2)?", leak_hex == expected_hex)
-    print("[GCM] XOR(ct1, ct2):", leak_hex)
-    print("[GCM] XOR(pt1, pt2):", expected_hex)
 
     # Show recovery of p2's differing middle when p1's middle is known
     start = len(prefix)
@@ -223,8 +279,27 @@ def demo_gcm_keystream_reuse_xor_leak():
     c1_mid = c1[start:end]
     c2_mid = c2[start:end]
     recovered_p2_mid = bytes(a ^ b ^ c for (a, b, c) in zip(c1_mid, c2_mid, mid1))
-    print("[GCM] Recover p2's middle given p1's middle:", recovered_p2_mid)
-    print("[GCM] p2 middle (expected):", mid2)
+
+    result = {
+        "key": key,
+        "nonce": nonce,
+        "ciphertexts": (c1, c2),
+        "leak_hex": leak_hex,
+        "expected_hex": expected_hex,
+        "recovered_mid": recovered_p2_mid,
+        "expected_mid": mid2,
+    }
+
+    if verbose:
+        print("[GCM] Key:", key.hex())
+        print("[GCM] Nonce reused:", nonce.hex())
+        print("[GCM] Keystream reuse: XOR(c1,c2) == XOR(p1,p2)?", leak_hex == expected_hex)
+        print("[GCM] XOR(ct1, ct2):", leak_hex)
+        print("[GCM] XOR(pt1, pt2):", expected_hex)
+        print("[GCM] Recover p2's middle given p1's middle:", recovered_p2_mid)
+        print("[GCM] p2 middle (expected):", mid2)
+
+    return result
 
 
 if __name__ == "__main__":

--- a/aes_modes/gcm_aad_demo.py
+++ b/aes_modes/gcm_aad_demo.py
@@ -1,11 +1,34 @@
+from __future__ import annotations
+
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
 
 
-def gcm_with_aad_demo():
-    key = bytes.fromhex("00112233445566778899aabbccddeeff")
-    nonce = get_random_bytes(12)
-    aad = b"hdr:v1;type=demo"
+def gcm_with_aad_demo(
+    *,
+    key: bytes | None = None,
+    nonce: bytes | None = None,
+    aad: bytes | None = None,
+):
+    """Run a short AES-GCM example that highlights the role of AAD.
+
+    Parameters are optional so tests can supply deterministic inputs.  The
+    function returns the cryptographic artefacts instead of only printing so
+    the caller can make assertions on the behaviour.
+    """
+
+    if key is None:
+        key = get_random_bytes(16)
+    if len(key) != 16:
+        raise ValueError("AES-128 demo expects a 16-byte key")
+
+    if nonce is None:
+        nonce = get_random_bytes(12)
+    if len(nonce) != 12:
+        raise ValueError("AES-GCM demo expects a 12-byte nonce")
+
+    if aad is None:
+        aad = b"hdr:v1;type=demo"
 
     pt = b"hello gcm with aad"
     enc = AES.new(key, AES.MODE_GCM, nonce=nonce)
@@ -22,17 +45,22 @@ def gcm_with_aad_demo():
     bad.update(aad[:-1] + bytes([aad[-1] ^ 1]))
     try:
         bad.decrypt_and_verify(ct, tag)
-        ok = False
-    except ValueError:
-        ok = True
+        tamper_fails = False
+        tamper_error = None
+    except ValueError as exc:
+        tamper_fails = True
+        tamper_error = type(exc).__name__
 
     # AAD tamper ⇒ verification failure.
     return {
+        "key": key.hex(),
         "nonce": nonce.hex(),
         "ct": ct.hex(),
         "tag": tag.hex(),
+        "aad_hex": aad.hex(),
         "aad_ok": True,
-        "aad_tamper_fails": ok,
+        "aad_tamper_fails": tamper_fails,
+        "aad_tamper_error": tamper_error,
     }
 
 


### PR DESCRIPTION
## Summary
- add optional verbosity controls so AES demo helpers return structured artefacts for easier testing
- replace ad-hoc randomness with `secrets` and random key generation to avoid hard-coded demo keys
- extend the GCM-with-AAD example to accept injectable parameters and report tamper failures programmatically

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2992754948320b63baabc97e61237