### PR TITLE
Fix Bleichenbacher slow demo performance regression

### DIFF
--- a/attacks/bleichenbacher_oracle.py
+++ b/attacks/bleichenbacher_oracle.py
@@ -326,8 +326,16 @@ def pkcs1v15_unpad(em: bytes) -> bytes:
         raise ValueError("Invalid padding")
     return em[sep + 1:]
 
-def oracle_padding_valid(c: int, d: int, n: int, e: int, k: int) -> bool:
-    m = decrypt_int(c, d, n, e=e)
+def oracle_padding_valid(
+    c: int,
+    d: int,
+    n: int,
+    e: int,
+    k: int,
+    *,
+    use_blinding: bool = False,
+) -> bool:
+    m = decrypt_int(c, d, n, e=e, use_blinding=use_blinding)
     em = os2ip(m, length=k)
     try:
         _ = pkcs1v15_unpad(em)
@@ -335,12 +343,20 @@ def oracle_padding_valid(c: int, d: int, n: int, e: int, k: int) -> bool:
     except ValueError:
         return False
 
-def oracle_padding_valid_prefix(c: int, d: int, n: int, e: int, k: int) -> bool:
+def oracle_padding_valid_prefix(
+    c: int,
+    d: int,
+    n: int,
+    e: int,
+    k: int,
+    *,
+    use_blinding: bool = False,
+) -> bool:
     """
     Fast/loose oracle: only checks that EM begins with 0x00 0x02.
     This is NON-COMPLIANT and only for demo speed-ups.
     """
-    m = decrypt_int(c, d, n, e=e)
+    m = decrypt_int(c, d, n, e=e, use_blinding=use_blinding)
     em = os2ip(m, length=k)
     return len(em) >= 2 and em.startswith(b"\x00\x02")
 
@@ -410,19 +426,29 @@ def demo_oracle(
     print(f"Padded plaintext EM: {em.hex()}")
     print(f"Ciphertext c: 0x{c:x}")
 
-    print(f"Oracle says padding valid? {oracle_padding_valid(c, d, n, e, k)} (expected True)")
+    print(
+        "Oracle says padding valid? "
+        f"{oracle_padding_valid(c, d, n, e, k, use_blinding=False)} (expected True)"
+    )
     c_bad = (c ^ 2) % n
     print(f"Tampered ciphertext c_bad: 0x{c_bad:x}")
-    print(f"Oracle says padding valid (tampered)? {oracle_padding_valid(c_bad, d, n, e, k)}")
+    print(
+        "Oracle says padding valid (tampered)? "
+        f"{oracle_padding_valid(c_bad, d, n, e, k, use_blinding=False)}"
+    )
 
-    fast_cb = (lambda ct: oracle_padding_valid_prefix(ct, d, n, e, k)) if use_fast else None
+    fast_cb = (
+        (lambda ct: oracle_padding_valid_prefix(ct, d, n, e, k, use_blinding=False))
+        if use_fast
+        else None
+    )
     want_trace = plot_path is not None
     result = bleichenbacher_attack(
         c,
         e,
         n,
         k,
-        oracle=lambda ct: oracle_padding_valid(ct, d, n, e, k),
+        oracle=lambda ct: oracle_padding_valid(ct, d, n, e, k, use_blinding=False),
         fast_oracle=fast_cb,
         return_trace=want_trace,
     )
@@ -459,9 +485,11 @@ def demo_fast_oracle(bits: int = 96, e: int = 3):
     def counting_oracle(ct: int) -> bool:
         nonlocal queries
         queries += 1
-        return oracle_padding_valid(ct, d, n, e_pub, k)
+        return oracle_padding_valid(ct, d, n, e_pub, k, use_blinding=False)
 
-    fast_cb = lambda ct: oracle_padding_valid_prefix(ct, d, n, e_pub, k)
+    fast_cb = lambda ct: oracle_padding_valid_prefix(
+        ct, d, n, e_pub, k, use_blinding=False
+    )
 
     recovered = bleichenbacher_attack(
         c,


### PR DESCRIPTION
## Summary
- disable RSA blinding in the Bleichenbacher demo oracles so slow mode performance matches earlier runs
- keep the ability to opt into blinding via a keyword argument without affecting other RSA helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2a41a34288320ad3d79efdf7872c7