### PR TITLE
Add HKDF utility and integrate AEAD demos

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -74,3 +74,17 @@ def test_bleichenbacher_fast_oracle():
 
     ok, iters = demo_fast_oracle()
     assert ok and iters > 0
+
+
+def test_dh_hkdf_aead():
+    from dh.dh_small_prime import dh_aead_demo
+
+    out = dh_aead_demo()
+    assert out["ok"] and isinstance(out["nonce"], bytes) and isinstance(out["tag"], bytes)
+
+
+def test_ecdh_hkdf_aead():
+    from ecdh.ecdh_tinyec import ecdh_aead_demo
+
+    out = ecdh_aead_demo()
+    assert out.get("ok", False)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for Lab 2 cryptography demos."""
+
+__all__ = [
+    "hkdf_sha256",
+]

--- a/utils/hkdf.py
+++ b/utils/hkdf.py
@@ -1,0 +1,25 @@
+"""Key derivation helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from typing import Optional
+
+
+def hkdf_sha256(ikm: bytes, *, salt: Optional[bytes] = None, info: bytes = b"", length: int = 32) -> bytes:
+    """HKDF-Extract-and-Expand with SHA-256 (RFC 5869)."""
+    if salt is None:
+        salt = b"\x00" * 32
+    prk = hmac.new(salt, ikm, hashlib.sha256).digest()
+    okm = b""
+    t = b""
+    counter = 1
+    while len(okm) < length:
+        t = hmac.new(prk, t + info + bytes([counter]), hashlib.sha256).digest()
+        okm += t
+        counter += 1
+    return okm[:length]
+
+
+__all__ = ["hkdf_sha256"]


### PR DESCRIPTION
## Summary
- add a reusable HKDF-SHA256 helper module for deriving symmetric keys
- extend the DH and ECDH demos to derive AES-GCM keys via HKDF and exercise authenticated encryption
- cover the new flows with smoke tests that tolerate missing tinyec installs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2b715dae08320bfd8fa673b3d6d42