### PR TITLE
Add Bleichenbacher interval plotting demo

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -92,6 +92,14 @@ def test_bleichenbacher_fast_oracle():
     assert ok and iters > 0
 
 
+def test_bleichenbacher_complexity_plot(tmp_path):
+    from attacks.bleichenbacher_oracle import demo_with_plot
+
+    out = demo_with_plot(tmp_path / "bb_complexity.png")
+    assert out["ok"]
+    assert (tmp_path / "bb_complexity.png").exists()
+
+
 def test_dh_hkdf_aead():
     from dh.dh_small_prime import dh_aead_demo
 


### PR DESCRIPTION
## Summary
- extend the Bleichenbacher attack helper to optionally collect interval widths each iteration
- add a demo helper that runs the fast oracle attack and saves a convergence plot
- cover the new plotting helper with a smoke test that ensures the PNG is written

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2ba14d4648320becdc6b72b28bb6a