### PR TITLE
Add dashboard export CLI entry and plotting utilities

### DIFF
--- a/lab2_cli.py
+++ b/lab2_cli.py
@@ -85,6 +85,9 @@ except Exception:
     bleichenbacher_demo = None
 
 from utils import console_ui
+from utils.plotting import HAS_MPL as _HAS_MPL
+
+from reports import make_all_dashboards as _dashboard_module
 
 _RSA_PADDING_NOTE_PRINTED = False
 _IN_RUN_ALL = False
@@ -130,6 +133,7 @@ def menu():
     print("  5) Bleichenbacher padding-oracle scaffold (optional)")
     print("  6) Entropy sanity checks")
     print("  7) Run ALL (in order)")
+    print("  8) Export dashboards (PNG)")
     print("  0) Exit")
     return input("\nEnter choice: ").strip()
 
@@ -630,6 +634,36 @@ def run_entropy_checks(*, wait_for_key: bool = True):
         input("\nPress Enter to return to the main menu...")
     return result
 
+
+def export_dashboards(*, wait_for_key: bool = True):
+    console_ui.section("Export Dashboards (PNG)")
+
+    if not _HAS_MPL:
+        console_ui.warning("matplotlib is not installed; skipping dashboard export.")
+        if wait_for_key:
+            input("\nPress Enter to return to the main menu...")
+        return []
+
+    try:
+        paths = _dashboard_module.make_all_dashboards()
+    except Exception as exc:  # pragma: no cover - runtime safeguard
+        console_ui.error(f"Dashboard export failed: {exc}")
+        if wait_for_key:
+            input("\nPress Enter to return to the main menu...")
+        return []
+
+    if paths:
+        console_ui.success("Saved dashboards:")
+        for path in paths:
+            print(f"  {pathlib.Path(path).resolve()}")
+    else:
+        console_ui.info("No dashboards were generated.")
+
+    if wait_for_key:
+        input("\nPress Enter to return to the main menu...")
+
+    return paths
+
 # Desired run_all output sample (for developers only):
 # [1/6] Preparing to run: AES Encryption Modes (ECB, CBC, GCM)
 # ================================================================================
@@ -737,11 +771,13 @@ def main():
             run_entropy_checks()
         elif choice == "7":
             run_all(wait_for_key=True)
+        elif choice == "8":
+            export_dashboards()
         elif choice == "0" or choice.lower() in {"q", "quit", "exit"}:
             print("Goodbye!")
             break
         else:
-            print("Invalid choice. Please select 0–7.")
+            print("Invalid choice. Please select 0–8.")
 
 if __name__ == "__main__":
     main()

--- a/reports/make_all_dashboards.py
+++ b/reports/make_all_dashboards.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from typing import Callable, List, Optional, Sequence, Tuple
+
+from utils.plotting import HAS_MPL, ensure_out_dir
+
+_DASHBOARD_SPECS: Sequence[Tuple[str, str, str]] = (
+    ("attacks.bleichenbacher_oracle", "make_attack_complexity_dashboard", "attack_complexity_analysis.png"),
+    ("ecdh.ecdh_tinyec", "make_ecdh_visualization", "ecdh_visualization.png"),
+    ("aes_modes.entropy_demo", "make_key_entropy_dashboard", "key_entropy_analysis.png"),
+    ("reports.performance_dashboard", "make_performance_dashboard", "performance_comparison.png"),
+)
+
+
+def _load_callable(module_name: str, attr: str) -> Optional[Callable[[Path], Optional[Path]]]:
+    try:
+        module = import_module(module_name)
+    except ImportError:
+        return None
+    return getattr(module, attr, None)
+
+
+def _invoke_dashboard(func: Optional[Callable[[Path], Optional[Path]]], target: Path) -> Optional[Path]:
+    if func is None:
+        print("skipped")
+        return None
+    try:
+        result = func(target)
+    except (ModuleNotFoundError, ImportError):
+        print("skipped")
+        return None
+    if result is None:
+        return target
+    return Path(result)
+
+
+def make_all_dashboards() -> List[Path]:
+    """Generate all available dashboards and return the paths that were written."""
+    if not HAS_MPL:
+        print("matplotlib is not available; skipping dashboard export.")
+        return []
+
+    out_dir = ensure_out_dir("out")
+    saved: List[Path] = []
+    for module_name, attr, filename in _DASHBOARD_SPECS:
+        func = _load_callable(module_name, attr)
+        target = out_dir / filename
+        path = _invoke_dashboard(func, target)
+        if path is not None:
+            saved.append(path)
+    return saved
+
+
+def main() -> None:
+    paths = make_all_dashboards()
+    for path in paths:
+        print(path.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/plotting.py
+++ b/utils/plotting.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+HAS_MPL = False
+plt = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    HAS_MPL = True
+except Exception:  # pragma: no cover - optional dependency missing
+    plt = None  # type: ignore[assignment]
+
+
+def ensure_out_dir(pathlike) -> Path:
+    """Ensure the given directory exists and return it as a Path."""
+    path = Path(pathlike)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+if HAS_MPL:  # pragma: no cover - tiny wrapper around matplotlib
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+
+    def new_figure(figsize: Tuple[float, float] = (16, 12)) -> Tuple[Figure, Axes]:
+        """Create a new figure and axis with a large default size."""
+        fig, ax = plt.subplots(figsize=figsize)
+        return fig, ax
+
+    def save(fig: Figure, path) -> Path:
+        """Save the figure to *path* (parent directories created automatically)."""
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(str(target), bbox_inches="tight")
+        plt.close(fig)
+        return target
+
+    def wide_grid(rows: int, cols: int):
+        """Create a grid of subplots suitable for dashboard-style layouts."""
+        fig, axes = plt.subplots(rows, cols, figsize=(cols * 5.5, rows * 3.5), squeeze=False)
+        return fig, axes
+
+    def nice_axes(
+        ax: Axes,
+        title: str,
+        xlabel: Optional[str] = None,
+        ylabel: Optional[str] = None,
+    ) -> Axes:
+        """Apply consistent styling to a matplotlib Axes object."""
+        ax.set_title(title)
+        if xlabel:
+            ax.set_xlabel(xlabel)
+        if ylabel:
+            ax.set_ylabel(ylabel)
+        ax.grid(True, alpha=0.3)
+        return ax
+
+else:  # pragma: no cover - exercised when matplotlib is unavailable
+
+    def new_figure(figsize: Tuple[float, float] = (16, 12)):
+        """Fallback that returns (None, None) when matplotlib is absent."""
+        return None, None
+
+    def save(fig, path) -> Path:
+        """Fallback save that simply ensures the destination directory exists."""
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        return target
+
+    def wide_grid(rows: int, cols: int):
+        """Fallback that returns (None, None) when matplotlib is absent."""
+        return None, None
+
+    def nice_axes(ax, title: str, xlabel: Optional[str] = None, ylabel: Optional[str] = None):
+        """Fallback that performs no styling when matplotlib is absent."""
+        return ax
+
+__all__ = [
+    "HAS_MPL",
+    "ensure_out_dir",
+    "new_figure",
+    "save",
+    "wide_grid",
+    "nice_axes",
+]


### PR DESCRIPTION
## Summary
- add a headless-safe plotting helper module and no-op fallbacks when matplotlib is unavailable
- scaffold a reports.make_all_dashboards runner that prepares the output directory and invokes dashboard generators
- extend the CLI with an "Export dashboards" option that surfaces saved PNG paths or a friendly warning when plotting is unavailable

## Testing
- pytest
- python -m reports.make_all_dashboards

------
https://chatgpt.com/codex/tasks/task_e_68e2c3c3b8388320a2c4c6f97fddb25a