### PR TITLE
Add ECC visualization dashboard export

### DIFF
--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -1,0 +1,7 @@
+"""Report generation helpers exposed at the package level."""
+
+from __future__ import annotations
+
+from .ecdh_visualization import make_ecdh_visualization
+
+__all__ = ["make_ecdh_visualization"]

--- a/reports/ecdh_visualization.py
+++ b/reports/ecdh_visualization.py
@@ -1,0 +1,20 @@
+"""Wrapper for generating the ECDH visualisation asset."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from ecdh.ecdh_tinyec import save_ecdh_visualization
+
+
+def make_ecdh_visualization(save_path: str | Path) -> Optional[Path]:
+    """Create the ECDH visualisation PNG, skipping gracefully if unavailable."""
+
+    try:
+        return save_ecdh_visualization(save_path)
+    except RuntimeError as exc:
+        if str(exc) == "tinyec not installed":
+            print("skipped")
+            return None
+        raise

--- a/reports/make_all_dashboards.py
+++ b/reports/make_all_dashboards.py
@@ -8,7 +8,7 @@ from utils.plotting import HAS_MPL, ensure_out_dir
 
 _DASHBOARD_SPECS: Sequence[Tuple[str, str, str]] = (
     ("attacks.bleichenbacher_oracle", "make_attack_complexity_dashboard", "attack_complexity_analysis.png"),
-    ("ecdh.ecdh_tinyec", "make_ecdh_visualization", "ecdh_visualization.png"),
+    ("reports.ecdh_visualization", "make_ecdh_visualization", "ecdh_visualization.png"),
     ("aes_modes.entropy_demo", "make_key_entropy_dashboard", "key_entropy_analysis.png"),
     ("reports.performance_dashboard", "make_performance_dashboard", "performance_comparison.png"),
 )
@@ -32,7 +32,7 @@ def _invoke_dashboard(func: Optional[Callable[[Path], Optional[Path]]], target: 
         print("skipped")
         return None
     if result is None:
-        return target
+        return target if target.exists() else None
     return Path(result)
 
 


### PR DESCRIPTION
## Summary
- add a save_ecdh_visualization helper that renders a four-panel elliptic-curve figure when tinyec/matplotlib are present
- expose a reports.ecdh_visualization wrapper that plugs the export into the dashboard runner and skips cleanly when dependencies are missing

## Testing
- python -m reports.make_all_dashboards

------
https://chatgpt.com/codex/tasks/task_e_68e2c57af76c8320bffe7905fc883a2b