### PR TITLE
Add summary reporting to dashboard export menu option

### DIFF
--- a/lab2_cli.py
+++ b/lab2_cli.py
@@ -638,8 +638,42 @@ def run_entropy_checks(*, wait_for_key: bool = True):
 def export_dashboards(*, wait_for_key: bool = True):
     console_ui.section("Export Dashboards (PNG)")
 
+    def _summarize(paths):
+        saved = {pathlib.Path(path).resolve() for path in paths}
+        specs = getattr(_dashboard_module, "_DASHBOARD_SPECS", ())
+        summary = {}
+        for module_name, _, filename in specs:
+            resolved = (pathlib.Path("out") / filename).resolve()
+            status = "saved" if resolved in saved else "skipped"
+            reason = ""
+            if status == "skipped":
+                missing_tinyec = False
+                ecdh_error = globals().get("_ecdh_import_error")
+                if isinstance(ecdh_error, ModuleNotFoundError) and ecdh_error.name in {"tinyec", "matplotlib"}:
+                    missing_tinyec = True
+                if not _HAS_MPL or ("ecdh" in module_name and missing_tinyec):
+                    reason = "tinyec/matplotlib not installed"
+
+            existing = summary.get(resolved)
+            if existing is None or existing["status"] == "skipped" and status == "saved":
+                summary[resolved] = {"status": status, "reason": reason}
+            elif existing["status"] == "skipped" and not existing["reason"]:
+                summary[resolved]["reason"] = reason
+        return summary
+
     if not _HAS_MPL:
         console_ui.warning("matplotlib is not installed; skipping dashboard export.")
+        summary = _summarize([])
+        if summary:
+            console_ui.section("Summary")
+            for path in sorted(summary):
+                entry = summary[path]
+                suffix = (
+                    " (skipped: tinyec/matplotlib not installed)"
+                    if entry.get("reason")
+                    else " (skipped)"
+                )
+                print(f"  {path}{suffix}")
         if wait_for_key:
             input("\nPress Enter to return to the main menu...")
         return []
@@ -658,6 +692,21 @@ def export_dashboards(*, wait_for_key: bool = True):
             print(f"  {pathlib.Path(path).resolve()}")
     else:
         console_ui.info("No dashboards were generated.")
+
+    summary = _summarize(paths)
+    if summary:
+        console_ui.section("Summary")
+        for path in sorted(summary):
+            entry = summary[path]
+            if entry["status"] == "saved":
+                print(f"  {path}")
+            else:
+                suffix = (
+                    " (skipped: tinyec/matplotlib not installed)"
+                    if entry.get("reason")
+                    else " (skipped)"
+                )
+                print(f"  {path}{suffix}")
 
     if wait_for_key:
         input("\nPress Enter to return to the main menu...")


### PR DESCRIPTION
## Summary
- add a summary helper that lists expected dashboard PNGs after exporting
- surface "skipped" entries with a dependency note when tinyec or matplotlib is missing

## Testing
- python -m compileall lab2_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e2c74eef58832097e78d2cbb833355