### PR TITLE
Expose visualization helpers for demos

### DIFF
--- a/attacks/bleichenbacher_oracle.py
+++ b/attacks/bleichenbacher_oracle.py
@@ -44,6 +44,22 @@ def estimate_bleich_calls(bits: int) -> tuple[int, int]:
     return min_calls, max_calls
 
 
+def make_attack_complexity_dashboard(save_path: str | Path) -> Path:
+    """Generate the Bleichenbacher attack complexity dashboard.
+
+    The visualisation logic lives in :mod:`reports.attack_complexity_dashboard` so
+    that it can be shared with other demos.  Import the implementation lazily to
+    avoid creating a circular import at module import time (the report module
+    depends on :func:`estimate_bleich_calls` from this file).
+    """
+
+    from reports.attack_complexity_dashboard import (  # local import to avoid cycle
+        make_attack_complexity_dashboard as _impl,
+    )
+
+    return _impl(save_path)
+
+
 @dataclass
 class IterationStats:
     """Telemetry for a single Bleichenbacher iteration."""

--- a/ecdh/ecdh_tinyec.py
+++ b/ecdh/ecdh_tinyec.py
@@ -33,6 +33,7 @@ __all__ = [
     "derive_symmetric_key",
     "ecdh_aead_demo",
     "save_ecdh_visualization",
+    "make_ecdh_visualization",
 ]
 
 
@@ -274,6 +275,12 @@ def save_ecdh_visualization(save_path: str | Path) -> Path:
     fig.savefig(save_path, dpi=200)
     plt.close(fig)
     return save_path
+
+
+def make_ecdh_visualization(save_path: str | Path) -> Path:
+    """Generate the ECDH visualisation expected by the demo harness."""
+
+    return save_ecdh_visualization(save_path)
 
 def _x_bytes(curve, P):
     coord_size = (curve.field.p.bit_length() + 7) // 8


### PR DESCRIPTION
## Summary
- add a Bleichenbacher dashboard wrapper so the demo runner can locate it in the attacks package
- expose the ECDH visualisation factory alongside the crypto helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2c9ef192883208d15162f47bb787e