### PR TITLE
Streamline dashboard exports and CLI flow

### DIFF
--- a/reports/attack_complexity_dashboard.py
+++ b/reports/attack_complexity_dashboard.py
@@ -51,6 +51,8 @@ def _prepare_bleich_ranges(sizes: Iterable[int]) -> tuple[list[int], list[int], 
 
 
 def make_attack_complexity_dashboard(save_path: str | Path) -> Path:
+    """Generate the cryptographic security analysis dashboard to PNG."""
+
     if not HAS_MPL:  # pragma: no cover - matplotlib optional dependency guard
         raise RuntimeError("matplotlib is required to generate dashboards")
 
@@ -130,8 +132,9 @@ def make_attack_complexity_dashboard(save_path: str | Path) -> Path:
     ax_d.set_ylim(0, 8.2)
     ax_d.legend()
 
-    fig.suptitle("Attack Complexity Dashboard (Illustrative Models)")
-    fig.tight_layout(rect=(0, 0, 1, 0.97))
+    fig.suptitle("Cryptographic Security Analysis (illustrative)")
+    fig.text(0.5, 0.01, "Illustrative scaling only; not a benchmark.", ha="center", fontsize=9)
+    fig.tight_layout(rect=(0, 0.03, 1, 0.95))
 
     target = save(fig, save_path)
     return target

--- a/reports/ecdh_visualization.py
+++ b/reports/ecdh_visualization.py
@@ -2,19 +2,58 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from ecdh.ecdh_tinyec import save_ecdh_visualization
+from utils.plotting import HAS_MPL
+
+_NOTE_TEXT = "Illustrative scaling only; not a benchmark."
+
+
+@contextmanager
+def _patched_figure_hooks() -> Iterator[None]:
+    """Temporarily append illustrative labels to the generated figure."""
+
+    if not HAS_MPL:
+        yield
+        return
+
+    from matplotlib.figure import Figure  # imported lazily for optional dependency
+
+    original_suptitle = Figure.suptitle
+    original_tight_layout = Figure.tight_layout
+
+    def patched_suptitle(self, t, *args, **kwargs):  # type: ignore[override]
+        if isinstance(t, str) and "(illustrative" not in t.lower():
+            t = f"{t} (illustrative)"
+        return original_suptitle(self, t, *args, **kwargs)
+
+    def patched_tight_layout(self, *args, **kwargs):  # type: ignore[override]
+        result = original_tight_layout(self, *args, **kwargs)
+        if not any(text.get_text() == _NOTE_TEXT for text in getattr(self, "texts", [])):
+            self.text(0.5, 0.01, _NOTE_TEXT, ha="center", fontsize=9)
+        return result
+
+    Figure.suptitle = patched_suptitle  # type: ignore[assignment]
+    Figure.tight_layout = patched_tight_layout  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        Figure.suptitle = original_suptitle  # type: ignore[assignment]
+        Figure.tight_layout = original_tight_layout  # type: ignore[assignment]
 
 
 def make_ecdh_visualization(save_path: str | Path) -> Optional[Path]:
-    """Create the ECDH visualisation PNG, skipping gracefully if unavailable."""
+    """Generate the ECDH visualization PNG, skipping gracefully if unavailable."""
 
     try:
+        if HAS_MPL:
+            with _patched_figure_hooks():
+                return save_ecdh_visualization(save_path)
         return save_ecdh_visualization(save_path)
     except RuntimeError as exc:
         if str(exc) == "tinyec not installed":
-            print("skipped")
             return None
         raise

--- a/reports/key_entropy_dashboard.py
+++ b/reports/key_entropy_dashboard.py
@@ -10,7 +10,7 @@ from typing import Dict, Iterable, Tuple
 from utils.entropy import shannon_entropy
 from utils.plotting import HAS_MPL, nice_axes, save, wide_grid
 
-_TITLE = "Key Entropy and Quality Analysis"
+_TITLE = "Key Entropy and Quality Analysis (illustrative)"
 _MAX_ENTROPY = 8.0
 
 _SAMPLES: Dict[str, bytes] = {
@@ -45,7 +45,7 @@ def _collision_probability(key_bits: int, count: float) -> float:
 
 
 def make_key_entropy_dashboard(save_path: str | Path) -> Path:
-    """Render the key entropy dashboard to *save_path* and return the file path."""
+    """Generate the key entropy dashboard and save to PNG."""
     target = Path(save_path)
     if not HAS_MPL:
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -117,5 +117,6 @@ def make_key_entropy_dashboard(save_path: str | Path) -> Path:
     ax_birthday.set_ylim(1e-20, 1.0)
     ax_birthday.legend(title="Key Count")
 
-    fig.tight_layout(rect=[0, 0, 1, 0.96])
+    fig.text(0.5, 0.01, "Illustrative scaling only; not a benchmark.", ha="center", fontsize=9)
+    fig.tight_layout(rect=[0, 0.03, 1, 0.96])
     return save(fig, target)

--- a/reports/make_all_dashboards.py
+++ b/reports/make_all_dashboards.py
@@ -1,38 +1,46 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from importlib import import_module
 from pathlib import Path
-from typing import Callable, List, Optional, Sequence, Tuple
+from typing import Callable, Optional, Sequence, Tuple, TypedDict
 
 from utils.plotting import HAS_MPL, ensure_out_dir
 
-_DASHBOARD_SPECS: Sequence[Tuple[str, str, str]] = (
-    ("attacks.bleichenbacher_oracle", "make_attack_complexity_dashboard", "attack_complexity_analysis.png"),
-    ("reports.ecdh_visualization", "make_ecdh_visualization", "ecdh_visualization.png"),
-    ("reports.attack_complexity_dashboard", "make_attack_complexity_dashboard", "attack_complexity_analysis.png"),
-    ("ecdh.ecdh_tinyec", "make_ecdh_visualization", "ecdh_visualization.png"),
-    ("reports.key_entropy_dashboard", "make_key_entropy_dashboard", "key_entropy_analysis.png"),
-    ("reports.performance_dashboard", "make_performance_dashboard", "performance_comparison.png"),
+_DASHBOARD_SPECS: Sequence[Tuple[str, str, str, str]] = (
+    (
+        "Cryptographic Security Analysis",
+        "reports.attack_complexity_dashboard",
+        "make_attack_complexity_dashboard",
+        "attack_complexity_analysis.png",
+    ),
+    (
+        "Elliptic Curve Cryptography Visualization",
+        "reports.ecdh_visualization",
+        "make_ecdh_visualization",
+        "ecdh_visualization.png",
+    ),
+    (
+        "Key Entropy and Quality Analysis",
+        "reports.key_entropy_dashboard",
+        "make_key_entropy_dashboard",
+        "key_entropy_analysis.png",
+    ),
+    (
+        "Cryptographic Performance and Security Trade-offs",
+        "reports.performance_dashboard",
+        "make_performance_dashboard",
+        "performance_comparison.png",
+    ),
 )
 
 
-@dataclass
-class DashboardResult:
-    """Outcome of a single dashboard export attempt."""
+class DashboardOutcome(TypedDict):
+    """Dictionary describing the outcome of a dashboard export."""
 
-    module: str
-    attr: str
-    target: Path
-    status: str
-    reason: str = ""
-    output: Optional[Path] = None
-
-    def resolved_target(self) -> Path:
-        return self.target.resolve()
-
-    def resolved_output(self) -> Optional[Path]:
-        return None if self.output is None else self.output.resolve()
+    title: str
+    path: Optional[Path]
+    skipped: bool
+    reason: Optional[str]
 
 
 def _load_callable(module_name: str, attr: str) -> Tuple[Optional[Callable[[Path], Optional[Path]]], str]:
@@ -50,100 +58,95 @@ def _load_callable(module_name: str, attr: str) -> Tuple[Optional[Callable[[Path
 def _invoke_dashboard(
     func: Callable[[Path], Optional[Path]],
     target: Path,
-    *,
-    module_name: str,
-    attr: str,
-) -> Tuple[Optional[Path], str]:
+) -> Tuple[Optional[Path], Optional[str]]:
     try:
         result = func(target)
     except (ModuleNotFoundError, ImportError) as exc:
         name = getattr(exc, "name", None) or str(exc)
         reason = f"missing dependency: {name}"
-        print(f"skipped {module_name}.{attr} ({reason})")
         return None, reason
+    except RuntimeError as exc:
+        message = str(exc)
+        if message == "tinyec not installed":
+            return None, "missing dependency: tinyec"
+        return None, f"error: {message}"
     except Exception as exc:  # pragma: no cover - runtime safeguard
-        reason = f"error: {exc}"
-        print(f"skipped {module_name}.{attr} ({reason})")
-        return None, reason
+        return None, f"error: {exc}"
     if result is None:
         if target.exists():
-            return target, ""
-        reason = "no output generated"
-        print(f"skipped {module_name}.{attr} ({reason})")
-        return None, reason
-    return Path(result), ""
+            return target, None
+        return None, "no output generated"
+    return Path(result), None
 
 
-def make_all_dashboards() -> List[DashboardResult]:
-    """Generate all available dashboards and describe the outcome of each attempt."""
+def make_all_dashboards() -> list[DashboardOutcome]:
+    """Generate all dashboards, printing a summary and returning detailed results."""
 
     out_dir = ensure_out_dir("out")
-    results: List[DashboardResult] = []
+    results: list[DashboardOutcome] = []
 
     if not HAS_MPL:
         reason = "matplotlib not installed"
         print("matplotlib is not available; skipping dashboard export.")
-        for module_name, attr, filename in _DASHBOARD_SPECS:
-            target = out_dir / filename
-            print(f"skipped {module_name}.{attr} ({reason})")
+        for title, _module_name, _attr, _filename in _DASHBOARD_SPECS:
+            print(f"Skipped: {title} ({reason})")
             results.append(
-                DashboardResult(
-                    module=module_name,
-                    attr=attr,
-                    target=target,
-                    status="skipped",
-                    reason=reason,
-                )
+                {
+                    "title": title,
+                    "path": None,
+                    "skipped": True,
+                    "reason": reason,
+                }
             )
         return results
 
-    for module_name, attr, filename in _DASHBOARD_SPECS:
+    for title, module_name, attr, filename in _DASHBOARD_SPECS:
         func, reason = _load_callable(module_name, attr)
         target = out_dir / filename
         if func is None:
-            print(f"skipped {module_name}.{attr} ({reason})")
+            print(f"Skipped: {title} ({reason})")
             results.append(
-                DashboardResult(
-                    module=module_name,
-                    attr=attr,
-                    target=target,
-                    status="skipped",
-                    reason=reason,
-                )
+                {
+                    "title": title,
+                    "path": None,
+                    "skipped": True,
+                    "reason": reason,
+                }
             )
             continue
 
-        path, invoke_reason = _invoke_dashboard(func, target, module_name=module_name, attr=attr)
+        path, invoke_reason = _invoke_dashboard(func, target)
         if path is None:
+            skip_reason = invoke_reason or reason or "unknown error"
+            print(f"Skipped: {title} ({skip_reason})")
             results.append(
-                DashboardResult(
-                    module=module_name,
-                    attr=attr,
-                    target=target,
-                    status="skipped",
-                    reason=invoke_reason or reason,
-                )
+                {
+                    "title": title,
+                    "path": None,
+                    "skipped": True,
+                    "reason": skip_reason,
+                }
             )
             continue
 
         resolved = Path(path)
+        absolute = resolved.resolve()
+        print(f"Saved: {title} -> {absolute}")
         results.append(
-            DashboardResult(
-                module=module_name,
-                attr=attr,
-                target=target,
-                status="saved",
-                output=resolved,
-            )
+            {
+                "title": title,
+                "path": absolute,
+                "skipped": False,
+                "reason": None,
+            }
         )
     return results
 
 
-def main() -> None:
-    results = make_all_dashboards()
-    for result in results:
-        if result.status == "saved" and result.output is not None:
-            print(result.output.resolve())
+def main() -> list[DashboardOutcome]:
+    """Entry point used by ``python -m reports.make_all_dashboards``."""
+
+    return make_all_dashboards()
 
 
 if __name__ == "__main__":

--- a/reports/performance_dashboard.py
+++ b/reports/performance_dashboard.py
@@ -14,14 +14,14 @@ def _ensure_path(path: str | Path) -> Path:
 
 
 def make_performance_dashboard(save_path: str | Path) -> Path:
-    """Create an illustrative dashboard covering perf/security trade-offs."""
+    """Generate the performance trade-off dashboard and save to PNG."""
     target = _ensure_path(save_path)
 
     if not HAS_MPL:
         return target
 
     fig, axes = wide_grid(2, 2)
-    fig.suptitle("Cryptographic Performance and Security Trade-offs")
+    fig.suptitle("Cryptographic Performance and Security Trade-offs (illustrative)")
 
     # Top-left: AES mode throughput comparison (illustrative numbers).
     aes_modes: Sequence[str] = ("ECB", "CBC", "GCM", "CTR", "CFB")
@@ -94,7 +94,8 @@ def make_performance_dashboard(save_path: str | Path) -> Path:
     for bar, status in zip(bars, statuses):
         ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 3, status, ha="center", va="bottom")
 
-    fig.tight_layout(rect=(0, 0, 1, 0.95))
+    fig.text(0.5, 0.01, "Illustrative scaling only; not a benchmark.", ha="center", fontsize=9)
+    fig.tight_layout(rect=(0, 0.03, 1, 0.94))
     return save(fig, target)
 
 

--- a/utils/plotting.py
+++ b/utils/plotting.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple, TYPE_CHECKING
 
 HAS_MPL = False
 plt = None  # type: ignore[assignment]
@@ -17,7 +17,12 @@ except Exception:  # pragma: no cover - optional dependency missing
     plt = None  # type: ignore[assignment]
 
 
-def ensure_out_dir(pathlike) -> Path:
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+
+
+def ensure_out_dir(pathlike: str | Path) -> Path:
     """Ensure the given directory exists and return it as a Path."""
     path = Path(pathlike)
     path.mkdir(parents=True, exist_ok=True)
@@ -33,7 +38,7 @@ if HAS_MPL:  # pragma: no cover - tiny wrapper around matplotlib
         fig, ax = plt.subplots(figsize=figsize)
         return fig, ax
 
-    def save(fig: Figure, path) -> Path:
+    def save(fig: Figure, path: str | Path) -> Path:
         """Save the figure to *path* (parent directories created automatically)."""
         target = Path(path)
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -41,10 +46,11 @@ if HAS_MPL:  # pragma: no cover - tiny wrapper around matplotlib
         plt.close(fig)
         return target
 
-    def wide_grid(rows: int, cols: int):
+    def wide_grid(rows: int, cols: int) -> Tuple[Figure, Tuple[Tuple[Axes, ...], ...]]:
         """Create a grid of subplots suitable for dashboard-style layouts."""
         fig, axes = plt.subplots(rows, cols, figsize=(cols * 5.5, rows * 3.5), squeeze=False)
-        return fig, axes
+        grid = tuple(tuple(row) for row in axes)
+        return fig, grid
 
     def nice_axes(
         ax: Axes,
@@ -63,21 +69,26 @@ if HAS_MPL:  # pragma: no cover - tiny wrapper around matplotlib
 
 else:  # pragma: no cover - exercised when matplotlib is unavailable
 
-    def new_figure(figsize: Tuple[float, float] = (16, 12)):
+    def new_figure(figsize: Tuple[float, float] = (16, 12)) -> Tuple[None, None]:
         """Fallback that returns (None, None) when matplotlib is absent."""
         return None, None
 
-    def save(fig, path) -> Path:
+    def save(fig: Any, path: str | Path) -> Path:
         """Fallback save that simply ensures the destination directory exists."""
         target = Path(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         return target
 
-    def wide_grid(rows: int, cols: int):
+    def wide_grid(rows: int, cols: int) -> Tuple[None, None]:
         """Fallback that returns (None, None) when matplotlib is absent."""
         return None, None
 
-    def nice_axes(ax, title: str, xlabel: Optional[str] = None, ylabel: Optional[str] = None):
+    def nice_axes(
+        ax: Any,
+        title: str,
+        xlabel: Optional[str] = None,
+        ylabel: Optional[str] = None,
+    ) -> Any:
         """Fallback that performs no styling when matplotlib is absent."""
         return ax
 


### PR DESCRIPTION
## Summary
- deduplicate dashboard specifications and return structured export results
- document dashboards/plotting helpers and mark figures as illustrative
- add a --no-pause CLI flag and streamline dashboard export messaging

## Testing
- python -m reports.make_all_dashboards
- python - <<'PY'
from lab2_cli import console_ui, export_dashboards
console_ui.init(plain=True)
export_dashboards(no_pause=True)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e2ca9a64208320ba3bd37edccffd99